### PR TITLE
Include compilation and running time in box tests exceptions

### DIFF
--- a/python/box.tests/test/org/jetbrains/kotlin/python/test/BasicIrBoxTest.kt
+++ b/python/box.tests/test/org/jetbrains/kotlin/python/test/BasicIrBoxTest.kt
@@ -142,7 +142,7 @@ abstract class BasicIrBoxTest(
             }
 
             if (!skipRegularMode) {
-                var compilationException: KotlinCompilationException? = null
+                var compilationException: Throwable? = null
                 val compiledModuleWithDuration: Pair<Long, CompilerResult?> = measureTimeMillisWithResult {
                     try {
                         compile(
@@ -163,14 +163,14 @@ abstract class BasicIrBoxTest(
                             propertyLazyInitialization = propertyLazyInitialization,
                         )
                     } catch (e: Throwable) {
-                        compilationException = KotlinCompilationException("Message should be set later. If you see this, it's a bug!", e)
+                        compilationException = e
                         null
                     }
                 }
                 val compilationTimeMessage = "Kotlin compilation time: ${compiledModuleWithDuration.first} ms"
 
-                if (compilationException != null) {
-                    throw KotlinCompilationException(compilationTimeMessage, compilationException!!.cause)
+                compilationException?.let {
+                    throw KotlinCompilationException(compilationTimeMessage, it)
                 }
                 val compiledModule = compiledModuleWithDuration.second!!
 

--- a/python/box.tests/test/org/jetbrains/kotlin/python/test/JsTestChecker.kt
+++ b/python/box.tests/test/org/jetbrains/kotlin/python/test/JsTestChecker.kt
@@ -118,8 +118,12 @@ object PythonTestChecker : AbstractJsTestChecker() {
         }
 
         if (exitValue != 0) {
-            val stderrReader = BufferedReader(InputStreamReader(process.errorStream))
-            val stderr = stderrReader.lineSequence().toList().takeLast(10).joinToString("\n")
+            val stderr = try {
+                val stderrReader = BufferedReader(InputStreamReader(process.errorStream))
+                stderrReader.lineSequence().toList().takeLast(10).joinToString("\n")
+            } catch (e: Exception) {
+                "There was a problem when extracting the contents of STDERR. Details: $e"
+            }
             throw PythonExecutionException("$runningTimeMessage\n$stderr")
         } else {
             val stdoutReader = BufferedReader(InputStreamReader(process.inputStream))


### PR DESCRIPTION
This change modifies the exceptions thrown in case of failed tests, so that they contain valuable data like Kotlin compilation time, Python running time, ability to infer if compilation or execution failed and why. Unfortunately it seems impossible with JUnit to include a standard error per test case, it's only included on test class level. That's why I need to attach this information to the exception which in turn **is** attached to individual test case.

It also tries to handle misbehaving Python processes gracefully (kills the one that run >10 s). It was needed to provide their running time.

# Testing

Ran it on a small subset of tests - it now provides some helpful data in `python/box.tests/build/test-results/pythonTest` that can be further analyzed by some tool (not in scope of this PR). However after this PR and even without any sophisticated tooling, it will be possible to grep through the XML test reports and e.g. count the number of `Python running time: still running` cases.

By the way, it makes running the whole test suite faster again (~1-2 h instead of 4-5) :tada: Probably thanks to killing Python processes that experience an infinite loop/stack overflow.

## Examples

Kotlin compilation issue:

```
Kotlin compilation time: 1653 ms
org.jetbrains.kotlin.python.test.KotlinCompilationException: Kotlin compilation time: 1653 ms
	at org.jetbrains.kotlin.python.test.BasicIrBoxTest.translateFiles(BasicIrBoxTest.kt:173)
...
Caused by: kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
	at org.jetbrains.kotlin.ir.backend.py.utils.MiscKt.TODO(misc.kt:25)
	at org.jetbrains.kotlin.ir.backend.py.transformers.irToPy.BaseIrElementToPyNodeTransformer$DefaultImpls.visitElement(BaseIrElementToPyNodeTransformer.kt:14
```

Python execution issue:

```
Python running time: 264 ms
...
  File "/home/piotr/repos/kotlin-python/python/py.translator/testData/out/codegen/irBox/argumentOrder/kt9277_v5.py5089678420921489858/compiled_module.py", line 4790, in Unit_getInstance
    if Unit_instance == None:
NameError: name 'Unit_instance' is not defined
	at org.jetbrains.kotlin.python.test.PythonTestChecker.runPython(JsTestChecker.kt:116
```

Python running timeout:

```
Python running time: 10000 ms
...
RecursionError: maximum recursion depth exceeded
	at org.jetbrains.kotlin.python.test.PythonTestChecker.runPython(JsTestChecker.kt:116
```