### PR TITLE
Improvements around constructors

### DIFF
--- a/compiler/ir/backend.py/src/org/jetbrains/kotlin/ir/backend/py/ir/IrBuilder.kt
+++ b/compiler/ir/backend.py/src/org/jetbrains/kotlin/ir/backend/py/ir/IrBuilder.kt
@@ -21,6 +21,20 @@ object JsIrBuilder {
     object SYNTHESIZED_STATEMENT : IrStatementOriginImpl("SYNTHESIZED_STATEMENT")
     object SYNTHESIZED_DECLARATION : IrDeclarationOriginImpl("SYNTHESIZED_DECLARATION")
 
+    fun buildConstructorCall(target: IrConstructorSymbol): IrConstructorCall {
+        val owner = target.owner
+        return IrConstructorCallImpl(
+            UNDEFINED_OFFSET,
+            UNDEFINED_OFFSET,
+            owner.returnType,
+            target,
+            typeArgumentsCount = owner.typeParameters.size,
+            valueArgumentsCount = owner.valueParameters.size,
+            constructorTypeArgumentsCount = 0, // TODO
+            origin = SYNTHESIZED_STATEMENT,
+        )
+    }
+
     fun buildCall(target: IrSimpleFunctionSymbol, type: IrType? = null, typeArguments: List<IrType>? = null): IrCall {
         val owner = target.owner
         return IrCallImpl(

--- a/python/experiments/box-tests-report.tsv
+++ b/python/experiments/box-tests-report.tsv
@@ -52,8 +52,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ar
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testArraysAreCloneable	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testCloneArray	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testClonePrimitiveArrays	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testCollectionAssignGetMultiIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testCollectionGetMultiIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testCollectionAssignGetMultiIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testCollectionGetMultiIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testForEachBooleanArray	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testForEachByteArray	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int8Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testForEachCharArray	Failed	PythonExecution	NameError: name 'Array' is not defined
@@ -63,10 +63,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ar
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testForEachLongArray	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testForEachShortArray	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int16Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testGenericArrayInObjectLiteralConstructor	Failed	PythonExecution	NameError: name 'Array' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testHashMap	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testHashMap	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testInProjectionAsParameter	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testInProjectionOfArray	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testInProjectionOfList	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testInProjectionOfList	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testIndices	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testIndicesChar	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testInlineInitializer	Failed	PythonExecution	NameError: name 'Array' is not defined
@@ -84,7 +84,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ar
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt1291	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt238	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt2997	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt33	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt33	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt34291_16dimensions	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt3771	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt4118	Failed	PythonExecution	NameError: name 'Array' is not defined
@@ -98,7 +98,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ar
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt7338	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt779	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt945	Failed	PythonExecution	NameError: name 'Array' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt950	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testKt950	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testLongAsIndex	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testMultiArrayConstructors	Failed	KotlinCompilation	java.lang.IllegalStateException: TOO_MANY_ARGUMENTS: Too many arguments for public fun <T> assertEquals(a: T, b: T): Unit defined in kotlin.test (20,49) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays > testNonLocalReturnArrayConstructor	Failed	PythonExecution	NameError: name 'Array' is not defined
@@ -112,8 +112,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ar
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testAllFilesPresentInForInReversed	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testReversedArrayOriginalUpdatedInLoopBody	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testReversedArrayReversedArrayOriginalUpdatedInLoopBody	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testReversedOriginalUpdatedInLoopBody	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testReversedReversedOriginalUpdatedInLoopBody	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testReversedOriginalUpdatedInLoopBody	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$ForInReversed > testReversedReversedOriginalUpdatedInLoopBody	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$MultiDecl > testAllFilesPresentInMultiDecl	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$MultiDecl > testKt15560	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Arrays$MultiDecl > testKt15568	Failed	PythonExecution	NameError: name 'Array' is not defined
@@ -146,10 +146,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bi
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testCallNullable	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testCompareBoxedChars	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testDivisionByZero	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoubles	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoublesToInt	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoublesToIntWithTP	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoublesWithTP	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoubles	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoublesToInt	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoublesToIntWithTP	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testEqNullableDoublesWithTP	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testIntrinsic	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testIntrinsicAny	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BinaryOp > testIntrinsicNullable	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
@@ -188,7 +188,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bo
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BoxingOptimization > testSimpleUninitializedMerge	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BoxingOptimization > testTaintedValues	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BoxingOptimization > testTaintedValuesBox	Failed	PythonExecution	TypeError: 'NoneType' object is not subscriptable
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BoxingOptimization > testUnsafeRemoving	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BoxingOptimization > testUnsafeRemoving	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BoxingOptimization > testVariables	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testAbstractOverrideBridge	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testAllFilesPresentInBridges	Succeeded		
@@ -214,7 +214,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Br
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt12416	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail #1]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt1939	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt1959	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt2498	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt2498	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt2702	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt2833	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testKt2920	Succeeded		
@@ -223,7 +223,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Br
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testLongChainOneBridge	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testManyTypeArgumentsSubstitutedSuccessively	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testMethodFromTrait	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testNoBridgeOnMutableCollectionInheritance	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testNoBridgeOnMutableCollectionInheritance	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testOverrideAbstractProperty	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testOverrideReturnType	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bridges > testPropertyAccessorsWithoutBody	Failed	PythonExecution	NameError: name 'js' is not defined
@@ -260,7 +260,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Bu
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods > testCustomReadOnlyIterator	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$ExtendJavaCollections > testAbstractSet	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$ExtendJavaCollections > testAllFilesPresentInExtendJavaCollections	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$ExtendJavaCollections > testArrayList	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$ExtendJavaCollections > testArrayList	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$ExtendJavaCollections > testHashMap	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$ExtendJavaCollections > testHashSet	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$BuiltinStubMethods$MapGetOrDefault > testAllFilesPresentInMapGetOrDefault	Succeeded		
@@ -300,18 +300,18 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ca
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences > testVarargViewedAsArray	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences > testVarargViewedAsPrimitiveArray	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences > testVarargWithDefaultValue	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testAdaptedWithCoercionToUnit	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testAdaptedWithCoercionToUnit	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testAdaptedWithDefaultArguments	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testAdaptedWithVarargs	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testAllFilesPresentInSuspendConversion	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testBound	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testBoundExtension	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testCrossInline	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineAdaptedWithCoercionToUnit	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testCrossInline	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineAdaptedWithCoercionToUnit	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineAdaptedWithDefaultArguments	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineAdaptedWithVarargs	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineBound	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineSimple	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineBound	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineSimple	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testInlineWithParameters	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testIsAs	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$AdaptedReferences$SuspendConversion > testNullableParameter	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
@@ -388,7 +388,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ca
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testGenericCallableReferencesWithNullableTypes	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testGenericCallableReferencesWithOverload	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testGenericMember	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testGenericWithDependentType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testGenericWithDependentType	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testGetArityViaFunctionImpl	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testInnerClassConstructorWithTwoReceivers	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testInnerConstructorFromClass	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
@@ -405,7 +405,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ca
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testOverloadedFunVsVal	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testPrivateClassMember	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testReferenceToCompanionMember	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testSortListOfStrings	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testSortListOfStrings	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testSpecialCalls	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testTopLevelFromClass	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CallableReference$Function > testTopLevelFromExtension	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
@@ -517,12 +517,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ca
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$LiteralExpressionAsGenericArgument > testUnaryExpressionCast	Failed	PythonExecution	NameError: name 'kotlin_Long' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$LiteralExpressionAsGenericArgument > testVararg	Failed	PythonExecution	NameError: name 'kotlin_Long' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testAllFilesPresentInMutableCollections	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testAsWithMutable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testIsWithMutable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testReifiedAsWithMutable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testReifiedIsWithMutable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testReifiedSafeAsWithMutable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testSafeAsWithMutable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testAsWithMutable	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testIsWithMutable	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testReifiedAsWithMutable	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testReifiedIsWithMutable	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testReifiedSafeAsWithMutable	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testSafeAsWithMutable	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Casts$MutableCollections > testWeirdMutableCasts	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CheckcastOptimization > testAllFilesPresentInCheckcastOptimization	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CheckcastOptimization > testKt19128	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
@@ -558,7 +558,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testDelegationGenericLongArg	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testDelegationJava	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testDelegationMethodsWithArgs	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testExceptionConstructor	Failed	PythonExecution	NameError: name '_undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testExceptionConstructor	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testExtensionFunWithDefaultParam	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testExtensionOnNamedClassObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testFunDelegation	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail #2]>
@@ -568,14 +568,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInheritedInnerClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInheritedMethod	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInitializerBlock	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInitializerBlockDImpl	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInitializerBlockDImpl	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInitializerBlockResetToDefault	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInnerClass	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1018	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1120	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1157	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1247	Failed	PythonExecution	TypeError: <lambda>() takes 1 positional argument but 2 were given
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1345	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1345	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1439	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1535	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1538	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
@@ -587,12 +587,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1891	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1918	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1976	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1980	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1980	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2224	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2384	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2390	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2391	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2417	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2391	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2417	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2477	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2480	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt2482	Succeeded		
@@ -609,7 +609,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt3001	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt3114	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt3414	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt343	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt343	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt3546	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt40332	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt454	Succeeded		
@@ -619,43 +619,43 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt500	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test0 failed]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt501	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt504	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt508	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt508	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt5347	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt6136	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt633	Failed	PythonExecution	NameError: name 'Array' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt6816	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt6816	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt707	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt723	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt725	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt8011	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt8011	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt8011a	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt940	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt9642	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testNamedClassObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOuterThis	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadBinaryOperator	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusAssign	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusAssignReturn	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusToPlusAssign	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadUnaryOperator	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadBinaryOperator	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusAssign	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusAssignReturn	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusToPlusAssign	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadUnaryOperator	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPrivateOuterFunctions	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x3__Expr__Expr__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPrivateOuterProperty	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Assign__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPrivateToThis	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPropertyDelegation	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail #2]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPropertyDelegation	Failed	PythonExecution	AttributeError: 'Derived1' object has no attribute 'plain'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPropertyInInitializer	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testQuotedClassName	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testRightHandOverride	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSelfcreate	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSelfcreate	Failed	PythonExecution	AttributeError: '_no_name_provided__9' object has no attribute 'b'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSimpleBox	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSuperConstructorCallWithComplexArg	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testTypedDelegation	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testAllFilesPresentInInner	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testExtensionWithOuter	Failed	PythonExecution	AttributeError: 'Inner' object has no attribute 'value'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInDerived	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail 3: fromC_]OK>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInDerivedLabeled	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInSameClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInDerived	Failed	PythonExecution	AttributeError: 'C' object has no attribute 'value'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInDerivedLabeled	Failed	PythonExecution	AttributeError: 'X' object has no attribute 'value'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInSameClass	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail 3: C_]OK>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testKt6708	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testProperOuter	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testProperOuter	Failed	PythonExecution	AttributeError: 'C' object has no attribute 's'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testProperSuperLinking	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testAllFilesPresentInClosures	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testAnonymousObjectAsLastExpressionInLambda	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Assign__Expr_' is not defined
@@ -672,7 +672,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testEnclosingLocalVariable	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x3__Assign__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testEnclosingThis	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testExtensionClosure	Failed	PythonExecution	TypeError: <lambda>() takes 1 positional argument but 2 were given
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testKt10044	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testKt10044	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Assign__Assign__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testKt11634	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testKt11634_2	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail: ]OK>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testKt11634_3	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail: ]OK>
@@ -707,32 +707,32 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testConstructorParameterCapturedInLambdaInLocalClass2	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt13454	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt14148	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'test_0_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt4174	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt4174	Failed	PythonExecution	AttributeError: 'A' object has no attribute 'f'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt4174a	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInAnonymousObjectInLocalClass	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'invoke_0_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInAnonymousObjectInLocalClass2	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'invoke_0_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInLambdaInInnerClassInLocalClass	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInLambdaInLocalClass	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalFunctionCapturedInLambda	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterAndLocalCapturedInLocalClass	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterAndLocalCapturedInLocalClass	Failed	PythonExecution	AttributeError: 'Local' object has no attribute 'fn'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedAsImplicitThisInBoundReference	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInFunctionLiteral	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInInlineLambda	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInInlineLambda2	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInLambda	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInLambda2	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInLambdaInSecondaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInLambdaInSecondaryConstructor	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInLambdaInSubExpression	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'x'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInLocalClass	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInNestedLambda	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInNestedObject	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'invoke_0_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInObject	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'invoke_0_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInObject2	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'invoke_0_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInPrimaryConstructorDefaultParameter	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInSecondaryConstructorDefaultParameter	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterEnumEntryCapturedInLambdaInInnerClass	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure1	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure2	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInPrimaryConstructorDefaultParameter	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInSecondaryConstructorDefaultParameter	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterEnumEntryCapturedInLambdaInInnerClass	Failed	PythonExecution	AttributeError: 'Inner' object has no attribute 'fn'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure1	Failed	PythonExecution	AttributeError: 'Local' object has no attribute 'fn'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure2	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testReferenceToCapturedVariablesInMultipleLambdas	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureOuterProperty > testAllFilesPresentInCaptureOuterProperty	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureOuterProperty > testCaptureFunctionInProperty	Succeeded		
@@ -755,19 +755,19 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testKt44347	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: listOf (17,9) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testKt45446	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testSharedSlotsWithCapturedVars	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testWithCoroutines	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testWithCoroutinesNoStdLib	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testWithCoroutines	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CapturedVarsOptimization > testWithCoroutinesNoStdLib	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testAllFilesPresentInClosureInsideClosure	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testLocalFunInsideLocalFun	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrCallImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testLocalFunInsideLocalFunDifferentSignatures	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrCallImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testPropertyAndFunctionNameClash	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testPropertyAndFunctionNameClash	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testThreeLevels	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrCallImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testThreeLevelsDifferentSignatures	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrCallImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$ClosureInsideClosure > testVarAsFunInsideLocalFun	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x1__If_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$CollectionLiterals > testAllFilesPresentInCollectionLiterals	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testAddCollectionStubWithCovariantOverride	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testAllFilesPresentInCollections	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testInSetWithSmartCast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testInSetWithSmartCast	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testInheritFromAbstractMutableListInt	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: AbstractMutableList (4,20) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testInternalRemove	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Collections > testKt41123	Failed	PythonExecution	NameError: name 'self' is not defined
@@ -902,7 +902,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testKt39374	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testKt45236	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testLambdaParameter	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testListAppend	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testListAppend	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testNestedLambdaInNonInlineCallExactlyOnce	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: listOf (19,16) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Contracts > testValInWhen	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testAllFilesPresentInControlStructures	Succeeded		
@@ -913,7 +913,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testConditionOfEmptyIf	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueInExpr	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueInFor	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail 1]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueInForCondition	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueInForCondition	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueInWhen	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueInWhile	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testContinueToLabelInFor	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail 1]>
@@ -962,10 +962,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt3203_1	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt3203_2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt3273	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt3280	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt3280	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt416	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt42455	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt513	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt513	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt628	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt769	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures > testKt772	Succeeded		
@@ -1016,67 +1016,67 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testAllFilesPresentInForInArrayWithIndex	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayOfObjectArrayWithIndex	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayOfPrimArrayWithIndex	Failed	PythonExecution	NameError: name 'Array' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexContinuesAsUnmodified	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexContinuesAsUnmodified	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNoIndexOrElementVar	Failed	PythonExecution	TypeError: object of type 'NoneType' has no len()
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNotDestructured	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInByteArrayWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexNotDestructured	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInArrayWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInByteArrayWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInByteArrayWithIndexWithSmartCast	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInEmptyArrayWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInGenericArrayOfIntsWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInEmptyArrayWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInGenericArrayOfIntsWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInGenericArrayOfIntsWithIndexWithSmartCast	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInGenericArrayWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInIntArrayWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInGenericArrayWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInIntArrayWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInIntArrayWithIndexWithSmartCast	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInObjectArrayWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInShortArrayWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInObjectArrayWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInShortArrayWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInArrayWithIndex > testForInShortArrayWithIndexWithSmartCast	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testAllFilesPresentInForInCharSequenceWithIndex	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSeqWithIndexStops	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceTypeParameterWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexNoElementVarCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexNoIndexVarCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSeqWithIndexStops	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceTypeParameterWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexNoElementVarCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInCharSequenceWithIndexNoIndexVarCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInEmptyStringWithIndex	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNoIndexOrElementVar	Failed	PythonExecution	TypeError: object of type 'NoneType' has no len()
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNotDestructured	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexNotDestructured	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInCharSequenceWithIndex > testForInStringWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testAllFilesPresentInForInIterableWithIndex	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInEmptyListWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableTypeParameterWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableWithIndexCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableWithIndexNoElementVarCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableWithIndexNoIndexVarCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInEmptyListWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableTypeParameterWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableWithIndexCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableWithIndexNoElementVarCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInIterableWithIndexNoIndexVarCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInIterableWithIndex > testForInListWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testAllFilesPresentInForInSequenceWithIndex	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInEmptySequenceWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceTypeParameterWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoElementVarCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoIndexVarCheckSideEffects	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInEmptySequenceWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceTypeParameterWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndex	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoElementVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoElementVarCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoIndexVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexNoIndexVarCheckSideEffects	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ForInSequenceWithIndex > testForInSequenceWithIndexWithExplicitlyTypedIndexVariable	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testAllFilesPresentInReturnsNothing	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testIfElse	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testIfElse	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testInlineMethod	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testPropertyGetter	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testPropertyGetter	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testTryCatch	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testWhen	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$ReturnsNothing > testWhen	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testAllFilesPresentInTryCatchInExpressions	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testCatch	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testComplexChain	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
@@ -1105,7 +1105,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryAfterTry	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryAndBreak	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryAndContinue	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryCatchAfterWhileTrue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryCatchAfterWhileTrue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryInsideCatch	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testTryInsideTry	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ControlStructures$TryCatchInExpressions > testUnmatchedInlineMarkers	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
@@ -1118,50 +1118,50 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testAwait	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testBeginWithException	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testBeginWithExceptionNoHandleException	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testBuilderInferenceAndGenericArrayAcessCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testBuilderInferenceAndGenericArrayAcessCall	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCaptureInfixFun	Failed	PythonExecution	NameError: name 'Object' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCaptureMutableLocalVariableInsideCoroutineBlock	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCaptureUnaryOperator	Failed	PythonExecution	NameError: name 'Object' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCapturedVarInSuspendLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCastWithSuspend	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCatchWithInlineInsideSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCatchWithInlineInsideSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCoercionToUnit	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testControllerAccessFromInnerLambda	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testControllerAccessFromInnerLambda	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCoroutineContextInInlinedLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCreateCoroutineSafe	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCreateCoroutinesOnManualInstances	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testCrossInlineWithCapturedOuterReceiver	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testDefaultParametersInSuspend	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testDelegatedSuspendMember	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testDispatchResume	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testDelegatedSuspendMember	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testDispatchResume	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testDoubleColonExpressionsGenerationInBuilderInference	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testEmptyClosure	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testEmptyClosure	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testEmptyCommonConstraintSystemForCoroutineInferenceCall	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testEpam	Failed	PythonExecution	SyntaxError: invalid syntax
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testFalseUnitCoercion	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testFalseUnitCoercion	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testGenerate	Failed	PythonExecution	NameError: name 'kotlin_CharSequence' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testHandleException	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testHandleException	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testHandleResultCallEmptyBody	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testHandleResultNonUnitExpression	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testHandleResultSuspended	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testIndirectInlineUsedAsNonInline	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlineFunInGenericClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlineFunInGenericClass	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlineGenericFunCalledFromSubclass	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlineSuspendFunction	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlineSuspendLambdaNonLocalReturn	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlinedTryCatchFinally	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlineSuspendLambdaNonLocalReturn	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInlinedTryCatchFinally	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInnerSuspensionCalls	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testInstanceOfContinuation	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testIterateOverArray	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt12958	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt15016	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt15017	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt15930	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt15930	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt21080	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt21605	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt24135	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt21605	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt24135	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt25912	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt28844	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt28844	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt30858	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt31784	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testKt35967	Succeeded		
@@ -1181,11 +1181,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testLongRangeInSuspendCall	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testLongRangeInSuspendFun	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testMergeNullAndString	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testMultipleInvokeCalls	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testMultipleInvokeCalls	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testMultipleInvokeCallsInsideInlineLambda1	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testMultipleInvokeCallsInsideInlineLambda2	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x3__Expr__Expr__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testMultipleInvokeCallsInsideInlineLambda3	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x5__Assign__Expr__Expr__Expr__Expr_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testNestedTryCatch	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testNestedTryCatch	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testNoSuspensionPoints	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testNonLocalReturn	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testNonLocalReturnFromInlineLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1200,7 +1200,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSimpleWithHandleResult	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testStatementLikeLastExpression	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testStopAfter	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspendCallsInArguments	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspendCallsInArguments	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspendCoroutineFromStateMachine	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspendDefaultImpl	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspendDelegation	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1216,11 +1216,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspendLambdaWithArgumentRearrangement	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspensionInsideSafeCall	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testSuspensionInsideSafeCallWithElvis	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTailCallToNothing	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryCatchFinallyWithHandleResult	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryCatchWithHandleResult	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTailCallToNothing	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryCatchFinallyWithHandleResult	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryCatchWithHandleResult	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryFinallyInsideInlineLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryFinallyWithHandleResult	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testTryFinallyWithHandleResult	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testVarCaptuedInCoroutineIntrinsic	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testVarValueConflictsWithTable	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines > testVarValueConflictsWithTableSameSort	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1230,37 +1230,37 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$Bridges > testLambdaWithLongReceiver	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$Bridges > testLambdaWithMultipleParameters	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testAllFilesPresentInControlFlow	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testBreakFinally	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testBreakStatement	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testComplexChainSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testDoWhileStatement	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testBreakFinally	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testBreakStatement	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testComplexChainSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testDoWhileStatement	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testDoWhileWithInline	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testDoubleBreak	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testFinallyCatch	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testForContinue	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testForStatement	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testForWithStep	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testIfStatement	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testKt22694_1_3	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testFinallyCatch	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testForContinue	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testForStatement	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testForWithStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testIfStatement	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testKt22694_1_3	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testLabeledWhile	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testMultipleCatchBlocksSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testMultipleCatchBlocksSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testReturnFromFinally	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testReturnWithFinally	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testSuspendInStringTemplate	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testSwitchLikeWhen	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testSwitchLikeWhen	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testThrowFromCatch	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testThrowFromFinally	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testThrowInTryWithHandleResult	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testWhenWithSuspensions	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testWhileStatement	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$ControlFlow > testWhileStatement	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$Debug > testAllFilesPresentInDebug	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testAllFilesPresentInFeatureIntersection	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testBreakWithNonEmptyStack	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testBreakWithNonEmptyStack	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testDefaultExpect	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testDelegate	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'setValue_gbl9e2_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testDestructuringInLambdas	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testFunInterface	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testInlineSuspendFinally	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testInlineSuspendFinally	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testInterfaceMethodWithBody	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testInterfaceMethodWithBodyGeneric	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testOverrideInInlineClass	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1269,7 +1269,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSafeCallOnTwoReceiversLong	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendDestructuringInLambdas	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendFunctionIsAs	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendInlineSuspendFinally	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendInlineSuspendFinally	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendOperatorPlus	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendOperatorPlusAssign	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection > testSuspendOperatorPlusCallFromLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1281,7 +1281,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Bound > testEmptyLHS	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Function > testAdapted	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Function > testAllFilesPresentInFunction	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Function > testGenericCallableReferencesWithNullableTypes	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Function > testGenericCallableReferencesWithNullableTypes	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Function$Local > testAllFilesPresentInLocal	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$CallableReference$Function$Local > testEqualsHashCode	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$JvmDefault > testAllFilesPresentInJvmDefault	Succeeded		
@@ -1289,16 +1289,16 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testAllFilesPresentInTailrec	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testControlFlowIf	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testControlFlowWhen	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testExtention	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testExtention	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testInfixCall	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testInfixRecursiveCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testInfixRecursiveCall	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testRealIteratorFoldl	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testRealStringEscape	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testRealStringRepeat	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testReturnInParentheses	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testReturnInParentheses	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testSum	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testTailCallInBlockInParentheses	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testTailCallInParentheses	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testTailCallInBlockInParentheses	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testTailCallInParentheses	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$FeatureIntersection$Tailrec > testWhenWithIs	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses > testAllFilesPresentInInlineClasses	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses > testGenericParameterResult	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: listOf (8,9) in <path-truncated>
@@ -1348,7 +1348,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Direct > testOverrideSuspendFun_Any_itf	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Direct > testOverrideSuspendFun_Any_this	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Direct > testOverrideSuspendFun_Int	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Direct > testReturnResult	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Direct > testReturnResult	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Direct > testSyntheticAccessor	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testAllFilesPresentInResume	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testBoxReturnValueOfSuspendFunctionReference	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1395,7 +1395,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testOverrideSuspendFun_Any_itf	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testOverrideSuspendFun_Any_this	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testOverrideSuspendFun_Int	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testReturnResult	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testReturnResult	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$Resume > testSyntheticAccessor	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testAllFilesPresentInResumeWithException	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testBoxReturnValueOfSuspendFunctionReference	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -1439,18 +1439,18 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testOverrideSuspendFun_Any_itf	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testOverrideSuspendFun_Any_this	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testOverrideSuspendFun_Int	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testReturnResult	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$InlineClasses$ResumeWithException > testReturnResult	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testAllFilesPresentInIntLikeVarSpilling	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testComplicatedMerge	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testI2bResult	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testComplicatedMerge	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testI2bResult	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testListThrowablePairInOneSlot	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testLoadFromBooleanArray	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testLoadFromByteArray	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testNoVariableInTable	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testSameIconst1ManyVars	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testLoadFromBooleanArray	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testLoadFromByteArray	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testNoVariableInTable	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testSameIconst1ManyVars	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testUnusedCatchVar	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testUsedInMethodCall	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testUsedInVarStore	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testUsedInMethodCall	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntLikeVarSpilling > testUsedInVarStore	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntrinsicSemantics > testAllFilesPresentInIntrinsicSemantics	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntrinsicSemantics > testCoroutineContext	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$IntrinsicSemantics > testCoroutineContextReceiver	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1466,10 +1466,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Anonymous > testAllFilesPresentInAnonymous	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Anonymous > testSimple	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testAllFilesPresentInNamed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testCallTopLevelFromLocal	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testCallTopLevelFromLocal	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testCapturedParameters	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testCapturedVariables	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testDefaultArgument	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testDefaultArgument	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testExtension	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testInfix	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$LocalFunctions$Named > testInsideLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1488,7 +1488,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$MultiModule > testInlineTailCall	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$MultiModule > testSimple	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$RedundantLocalsElimination > testAllFilesPresentInRedundantLocalsElimination	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$RedundantLocalsElimination > testKtor_receivedMessage	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$RedundantLocalsElimination > testKtor_receivedMessage	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$Reflect > testAllFilesPresentInReflect	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$StackUnwinding > testAllFilesPresentInStackUnwinding	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$StackUnwinding > testException	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1503,14 +1503,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendConversion > testOnInlineArgument	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendConversion > testSubtypeOfFunctionalTypeToSuspendConversion	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testAllFilesPresentInSuspendFunctionAsCoroutine	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testDispatchResume	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testHandleException	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testDispatchResume	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testHandleException	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testIfExpressionInsideCoroutine_1_3	Failed	KotlinCompilation	java.lang.IllegalStateException: org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl@... for VAR SYNTHESIZED_DECLARATION name:tmp type:kotlin.Unit [var] has unexpected parent org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl@...
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testInline	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testInlineTwoReceivers	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testMember	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testNoinlineTwoReceivers	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testOperators	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testOperators	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testPrivateFunctions	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testPrivateInFile	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$SuspendFunctionAsCoroutine > testReturnNoSuspend	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -1529,7 +1529,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations > testAllFilesPresentInTailCallOptimizations	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations > testCrossinline	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations > testInlineWithoutStateMachine	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations > testInnerObjectRetransformation	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations > testInnerObjectRetransformation	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations > testTryCatch	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailCallOptimizations$Unit > testAllFilesPresentInUnit	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$TailOperations > testAllFilesPresentInTailOperations	Succeeded		
@@ -1541,14 +1541,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Co
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testCoroutineNonLocalReturn	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testCoroutineReturn	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testInlineUnitFunction	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testInterfaceDelegation	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testSuspendNonLocalReturn	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testSuspendReturn	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testInterfaceDelegation	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testSuspendNonLocalReturn	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testSuspendReturn	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$UnitTypeReturn > testUnitSafeCall	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testAllFilesPresentInVarSpilling	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testFakeInlinerVariables	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testKt19475	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testKt38925	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testKt38925	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testNullSpilling	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testRefinedIntTypesAnalysis	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Coroutines$VarSpilling > testSafeCallElvis	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -1569,21 +1569,21 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Da
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses > testTwoVarParams	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses > testUnitComponent	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testAllFilesPresentInCopy	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testConstructorWithDefaultParam	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testConstructorWithDefaultParam	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testCopyInObjectNestedDataClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testKt12708	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testKt3033	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testValInConstructorParams	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testVarInConstructorParams	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testWithGenericParameter	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testWithSecondaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testWithSecondaryConstructor	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testAllFilesPresentInEquals	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testAlreadyDeclared	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testGenericarray	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testIntarray	Failed	PythonExecution	TypeError: __init__() takes 2 positional arguments but 4 were given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testNull	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testNullother	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testSameinstance	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testSameinstance	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$HashCode > testAllFilesPresentInHashCode	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$HashCode > testAlreadyDeclared	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$HashCode > testBoolean	Succeeded		
@@ -1630,17 +1630,17 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testAllFilesPresentInConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testAnnotation	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testAnnotationWithEmptyArray	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs1	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs1InnerClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs2	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDoubleDefArgs1InnerClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnum	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithOneDefArg	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithTwoDefArgs	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithTwoDoubleDefArgs	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testInnerClass32Args	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt2852	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt30517	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs1	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs1InnerClass	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs2	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDoubleDefArgs1InnerClass	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnum	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithOneDefArg	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithTwoDefArgs	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithTwoDoubleDefArgs	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testInnerClass32Args	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt2852	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt30517	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt3060	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrGetFieldImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testObjectExpressionDelegatingToSecondaryConstructor	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Convention > testAllFilesPresentInConvention	Succeeded		
@@ -1682,18 +1682,18 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testAllFilesPresentInPrivate	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testMemberExtensionFunction	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testMemberFunction	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testPrimaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testSecondaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testPrimaryConstructor	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testSecondaryConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testAllFilesPresentInSignature	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt2789	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail 1: 16 != None]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt9428	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt9428	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt9924	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testAccessTopLevelDelegatedPropertyInClinit	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testAllFilesPresentInDelegatedProperty	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testBeforeDeclarationContainerOptimization	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testCapturePropertyInClosure	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testCastGetReturnType	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testCastSetParameter	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testCastSetParameter	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testDelegateAsInnerClass	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testDelegateByOtherProperty	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testDelegateByTopLevelFun	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -1733,7 +1733,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testTwoPropByOneDelegete	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'getValue_d8h4ck_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testUseKPropertyLater	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'setValue_efudr6_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testUseReflectionOnKProperty	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testValByMapDelegatedProperty	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testValByMapDelegatedProperty	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testValInInnerClass	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty > testVarInInnerClass	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$Local > testAllFilesPresentInLocal	Succeeded		
@@ -1766,16 +1766,16 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$OptimizedDelegatedProperties > testMixedArgumentSizes	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testAllFilesPresentInProvideDelegate	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testDelegatedPropertyWithIdProvideDelegate	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testDifferentReceivers	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testDifferentReceivers	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testEvaluationOrder	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testEvaluationOrderVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testExtensionDelegated	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'getValue_9ou11a_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testGeneric	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testGeneric	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testGenericDelegateWithNoAdditionalInfo	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testGenericProvideDelegateOnNumberLiteral	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'getValue_d8h4ck_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testHostCheck	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testInClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testInlineProvideDelegate	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testInClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testInlineProvideDelegate	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testKt15437	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'getValue_1kobyo_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testKt16441	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testKt18902	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -1784,17 +1784,17 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testLocalCaptured	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testLocalDifferentReceivers	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testMemberExtension	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testPropertyMetadata	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testPropertyMetadata	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testProvideDelegateByExtensionFunction	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testAllFilesPresentInDelegation	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testDelegationDifferentModule	Failed	BoxTestsFailure	java.lang.IllegalStateException: Can't find compiled module for dependency <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testDelegationWithPrivateConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testDelegationWithPrivateConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testGenericProperty	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testHiddenSuperOverrideIn1_0	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testInDataClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testKt30102_comparable	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testKt8154	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testViaTypeAlias	Failed	PythonExecution	NameError: name 'js' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testViaTypeAlias	Failed	PythonExecution	AttributeError: 'B' object has no attribute 'm'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testWithDefaultParameters	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail1: [2] object:C.foo(2);]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testAllFilesPresentInDestructuringDeclInLambdaParam	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testExtensionComponents	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x7__Assign__Expr__Assign__Expr__Assign__Expr__Return_' is not defined
@@ -1804,7 +1804,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testSimple	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x5__Assign__Expr__Assign__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testStdlibUsages	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testUnderscoreNames	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x5__Assign__Expr__Assign__Expr__Return_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testWithIndexed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DestructuringDeclInLambdaParam > testWithIndexed	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics > testAllFilesPresentInDiagnostics	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions > testAllFilesPresentInFunctions	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$Inference > testAllFilesPresentInInference	Succeeded		
@@ -1839,7 +1839,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Di
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testMultilevelBlocks	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRealIteratorFoldl	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRealStringEscape	Failed	PythonExecution	SyntaxError: EOL while scanning string literal
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRealStringRepeat	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRealStringRepeat	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRecursiveCallInInlineLambda	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRecursiveCallInInlineLambdaWithCapture	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: it (8,26) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Functions$TailRecursion > testRecursiveCallInLambda	Succeeded		
@@ -1867,8 +1867,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Di
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Vararg > testAllFilesPresentInVararg	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Diagnostics$Vararg > testKt4172	Failed	PythonExecution	TypeError: isArray() missing 1 required positional argument: 'obj'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testAllFilesPresentInElvis	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testGenericElvisWithMoreSpecificLHS	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testGenericElvisWithNullLHS	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testGenericElvisWithMoreSpecificLHS	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testGenericElvisWithNullLHS	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testGenericNull	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testKt6694ExactAnnotationForElvis	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testNullNullOk	Succeeded		
@@ -1884,7 +1884,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$En
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testConstructorWithReordering	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testDeepInnerClassInEnumEntryClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testDeepInnerClassInEnumEntryClass2	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEmptyConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEmptyConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEmptyEnumValuesValueOf	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEnumCompanionInit	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEnumConstructorParameterClashWithDefaults	Failed	PythonExecution	SyntaxError: duplicate argument 'name' in function definition
@@ -1932,7 +1932,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$En
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testKt7257_notInline	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testKt9711	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testKt9711_2	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testManyDefaultParameters	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testManyDefaultParameters	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testObjectInEnum	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail 2]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testOrdinal	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testOverloadedEnumValues	Succeeded		
@@ -1944,11 +1944,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$En
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testValueof	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testWhenInObject	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'f_2bq_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testAllFilesPresentInDefaultCtor	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testConstructorWithDefaultArguments	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testConstructorWithDefaultArguments	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testConstructorWithVararg	Failed	PythonExecution	NameError: name 'translateCallArguments_2' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testEntryClassConstructorWithDefaultArguments	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testEntryClassConstructorWithDefaultArguments	Failed	PythonExecution	AttributeError: 'OK' object has no attribute 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testEntryClassConstructorWithVarargs	Failed	PythonExecution	NameError: name 'translateCallArguments_2' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testSecondaryConstructorWithDefaultArguments	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testSecondaryConstructorWithDefaultArguments	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testSecondaryConstructorWithVararg	Failed	PythonExecution	NameError: name 'translateCallArguments_2' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Evaluate > testAllFilesPresentInEvaluate	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Evaluate > testKt9443	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail: None]>
@@ -1964,18 +1964,18 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ex
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt1290	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt13312	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt1776	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt1953	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt1953_class	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt1953	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt1953_class	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt23675	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt3285	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt3298	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x1__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt3646	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt3969	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt4228	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt475	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt475	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt5467	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt606	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt865	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testKt865	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testMemberExtensionEqualsHashCodeToStringInInterface	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testNested2	Failed	PythonExecution	TypeError: <lambda>() takes 1 positional argument but 2 were given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExtensionFunctions > testShared	Succeeded		
@@ -2070,7 +2070,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Fu
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testAllFilesPresentInEquality	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testFunctionReferencesBound	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testFunctionReferencesUnbound	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testLambdaRuntimeConversion	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testLambdaRuntimeConversion	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testLocalFunctionReferences	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$FunInterface$Equality > testSimpleLambdas	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testAllFilesPresentInFunctions	Succeeded		
@@ -2096,7 +2096,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Fu
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt1649_1	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt1649_2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt1739	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2270	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2270	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2271	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2280	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrCallImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2481	Failed	PythonExecution	There was a problem when extracting the contents of STDERR. Details: java.io.IOException: Stream closed
@@ -2247,7 +2247,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testGenericClassWithGetSet	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testKt36956	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testMemberExtOnLong	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'ExtProvider' and 'int'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testMutableListElement	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testMutableListElement	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testNullable	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testPostfixIncrementDoubleSmartCast	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Increment > testPostfixIncrementOnClass	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
@@ -2270,7 +2270,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testCoerctionToUnitForLastExpressionWithStarProjection	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x4__If__Assign__If__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testEarlyReturnInsideCrossinlineLambda	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrGetValueImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testInferenceWithTypeVariableInsideCapturedType	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testIntegerLiteralTypeInLamdaReturnType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testIntegerLiteralTypeInLamdaReturnType	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testKt10822	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testKt35684	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testKt36446	Succeeded		
@@ -2289,7 +2289,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testReferenceToCatchParameterFromLambdaExpression	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testSpecialCallsWithCallableReferences	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: setOf (98,25) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testSumOfOverloads	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: listOf (5,13) in <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testSuspendExtensionRecevierFromConstraint	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testSuspendExtensionRecevierFromConstraint	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference > testUnsafeVarianceCodegen	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference$BuilderInference > testAllFilesPresentInBuilderInference	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference$BuilderInference > testBuilderCallAsReturnTypeInLocalClass	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE_WRONG_RECEIVER: Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
@@ -2312,8 +2312,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Inference$BuilderInference > testTopDownCompletionWithTwoBuilderInferenceCalls	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testAllFilesPresentInInlineClasses	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testAnnotatedMemberExtensionProperty	Failed	PythonExecution	AttributeError: 'A' object has no attribute 's'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testAnySuperCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBoundCallableReferencePassedToInlineFunction	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testAnySuperCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBoundCallableReferencePassedToInlineFunction	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBoxImplDoesNotExecuteInSecondaryConstructor	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBoxImplDoesNotExecuteInitBlock	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBoxNullableValueOfInlineClassWithNonNullUnderlyingType	Succeeded		
@@ -2323,18 +2323,18 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBoxUnboxOfInlineClassForCapturedVars	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBridgeForFunctionReturningInlineClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBridgeGenerationWithInlineClassOverAny	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBridgesWhenInlineClassImplementsGenericInterface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testBridgesWhenInlineClassImplementsGenericInterface	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCallComputablePropertyInsideInlineClass	Failed	PythonExecution	TypeError: _Props___init__impl_() takes 1 positional argument but 3 were given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCallableReferencesWithInlineClasses	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCastInsideWhenExpression	Failed	PythonExecution	NameError: name 'Foo_T_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxUnboxOfArgumentsOnInlinedFunctions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingAfterAssertionOperator	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingForComplexClassHierarchy	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxUnboxOfArgumentsOnInlinedFunctions	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingAfterAssertionOperator	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingForComplexClassHierarchy	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingForNonLocalAndLabeledReturns	Failed	PythonExecution	NameError: name 'kotlin_ULong' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingFromReturnTypeForInlineClasses	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingOnFunctionCalls	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingOnLocalVariableAssignments	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingUnboxingForInheritedTypeSpecializedFunctions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingFromReturnTypeForInlineClasses	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingOnFunctionCalls	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingOnLocalVariableAssignments	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckBoxingUnboxingForInheritedTypeSpecializedFunctions	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckCallingMembersInsideInlineClass	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toString'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckCastToInlineClass	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckForInstanceOfInlineClass	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
@@ -2342,51 +2342,51 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCheckUnboxingResultFromTypeVariable	Failed	PythonExecution	NameError: name 'Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testClassInInlineClassInit	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testComputablePropertyInsideInlineClass	Failed	PythonExecution	TypeError: _UIntArray___init__impl_() takes 1 positional argument but 3 were given
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testConformToComparableAndCallInterfaceMethod	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testConformToComparableAndCallInterfaceMethod	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testConstructorCallableReference	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCorrectBoxingForBranchExpressions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCreateInlineClassInArgumentPosition	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCorrectBoxingForBranchExpressions	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCreateInlineClassInArgumentPosition	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCrossinlineWithInlineClassInParameter	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testCustomIterator	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: substring (22,32) in <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testDefaultFunctionsFromAnyForInlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testDefaultInterfaceMethodsInInlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testDefaultFunctionsFromAnyForInlineClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testDefaultInterfaceMethodsInInlineClass	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testDefaultWithInlineClassArgument	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testElvisWithInlineClassAndNullConstant	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEmptyConstructorForInlineClass	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksInlineClassNonNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksMixedNullability	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedInlineClassNonNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedNonNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedNullable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNonNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNullable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityForBoxesOfNullableValuesOfInlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsCallsLeftArgument	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksInlineClassNonNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksMixedNullability	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedInlineClassNonNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedNonNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedNullable	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNegatedPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNonNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksNullable	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityChecksPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualityForBoxesOfNullableValuesOfInlineClass	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsCallsLeftArgument	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsEvaluationOrderInlineClass	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsEvaluationOrderNonNull	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsEvaluationOrderNullable	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsEvaluationOrderPrimitive	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsOperatorWithGenericCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testExtLambdaInInlineClassFun	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testExtLambdaInInlineClassFun2	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testEqualsOperatorWithGenericCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testExtLambdaInInlineClassFun	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testExtLambdaInInlineClassFun2	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testFieldNameClash	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testGenericInlineClassSynthMembers	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testGenericVararg2ndConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testGenericVararg2ndConstructor	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInitBlock	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x3__Global__Assign__Expr_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassAsLastExpressionInInLambda	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassEqualityShouldUseTotalOrderForFloatingPointData	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassAsLastExpressionInInLambda	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassEqualityShouldUseTotalOrderForFloatingPointData	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassFieldHandling	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassFunctionInvoke	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassInInitBlock	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassInStringTemplate	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassInStringTemplate	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassPropertyReferenceGetAndSet	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassValueCapturedInInlineLambda	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassValueCapturedInNonInlineLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassValuesInsideStrings	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassWithCustomEquals	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassWithDefaultFunctionsFromAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassValuesInsideStrings	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassWithCustomEquals	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassWithDefaultFunctionsFromAny	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassesAsInlineFunParameters	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassesCheckCast	Failed	PythonExecution	NameError: name 'AsAny_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineClassesInInlineLambdaParameters	Succeeded		
@@ -2394,25 +2394,25 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineExtLambdaInInlineClassFun	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineExtLambdaInInlineClassFun2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testInlineFunctionInsideInlineClass	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testIterateOverArrayOfInlineClassValues	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testIterateOverListOfInlineClassValues	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testIterateOverArrayOfInlineClassValues	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testIterateOverListOfInlineClassValues	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt25246	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt25750	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt25771	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt26103	Failed	PythonExecution	NameError: name 'Foo_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt26103_contravariantUnderlyingType	Failed	PythonExecution	NameError: name 'GCmp_T_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt26103_covariantUnderlyingType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt26103_covariantUnderlyingType	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt26103_original	Failed	PythonExecution	NameError: name 'Foo_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_enum	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_functional	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_innerClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_nullablePrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_nullableReference	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_primitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_reference	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_enum	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_functional	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_innerClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_nullablePrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_nullableReference	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_primitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27096_reference	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27113	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27113a	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27113a	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27132	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27140	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int8Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt27705	Succeeded		
@@ -2420,14 +2420,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt28405	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt28585	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt31994	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt32793	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt32793	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt33119	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt34268	Failed	PythonExecution	NameError: name 'kotlin_ULong' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt34902	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt37998	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt38680	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt38680a	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt38680b	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt37998	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt38680	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt38680a	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt38680b	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt44141	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt44867	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testKt44978	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: withIndex (8,36) in <path-truncated>
@@ -2440,89 +2440,89 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNestedInlineClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNoAssertionsOnInlineClassBasedOnNullableType	Failed	PythonExecution	NameError: name 'Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNoReturnTypeMangling	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNullableEqeqNonNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNullableWrapperEquality	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testOverridingFunCallingPrivateFun	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNullableEqeqNonNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testNullableWrapperEquality	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testOverridingFunCallingPrivateFun	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testPassInlineClassAsVararg	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testPassInlineClassWithSpreadOperatorToVarargs	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testPropertyLoweringOrder	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testReferToPropertyInCompanionObjectOfInlineClass	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testReferToUnderlyingPropertyInsideInlineClass	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testReferToUnderlyingPropertyOfInlineClass	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testRemoveInInlineCollectionOfInlineClassAsInt	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testRemoveInInlineCollectionOfInlineClassAsInt	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testResult	Failed	KotlinCompilation	java.lang.IllegalStateException: Symbol for public kotlin/Result.Companion|null[0] is unbound
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testResultInlining	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testResultRunCatchingOrElse	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSafeAsOfTypeParameterWithInlineClassBound	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSafeAsOfTypeParameterWithInlineClassBound	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSecondaryConstructorWithVararg	Failed	PythonExecution	NameError: name 'translateCallArguments_0' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSecondaryConstructorsInsideInlineClass	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSecondaryConstructorsInsideInlineClassWithPrimitiveCarrierType	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSimpleSecondaryConstructor	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSmartCastOnThisOfInlineClassType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testSmartCastOnThisOfInlineClassType	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testStringPlus	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testToStringCallingPrivateFun	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testToStringOfUnboxedNullable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testTypeChecksForInlineClasses	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testToStringCallingPrivateFun	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testToStringOfUnboxedNullable	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testTypeChecksForInlineClasses	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUIntArraySortExample	Failed	PythonExecution	AttributeError: 'UIntArray' object has no attribute 'intArray'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUIntSafeAsInt	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxNullableValueOfInlineClassWithNonNullUnderlyingType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxNullableValueOfInlineClassWithPrimitiveUnderlyingType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxNullableValueOfInlineClassWithNonNullUnderlyingType	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxNullableValueOfInlineClassWithPrimitiveUnderlyingType	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxParameterOfSuspendLambdaBeforeInvoke	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxReceiverOnCallingMethodFromInlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxValueFromPlatformType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxReceiverOnCallingMethodFromInlineClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxValueFromPlatformType	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUnboxValueOfAnyBeforeMethodInvocation	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'get_ha5a7z_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUseInlineClassesInsideElvisOperator	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUseInlineFunctionInsideInlineClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testUseThisInsideInlineClass	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testWhenWithSubject	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses > testWhenWithSubject	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testAllFilesPresentInBoxReturnValueInLambda	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxFunLiteralAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxInt	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableAnyNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableInt	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableIntNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableStringNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxFunLiteralAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxInt	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableAnyNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableInt	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableIntNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableString	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxNullableStringNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testBoxString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testKt27586_1	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueInLambda > testKt27586_2	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testAllFilesPresentInBoxReturnValueOnOverride	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testBoxReturnValueInDefaultMethod	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideChainErasedToAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideChainErasedToNullableAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideErasedToAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideErasedToInterface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testBoxReturnValueInDefaultMethod	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideChainErasedToAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideChainErasedToNullableAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideErasedToAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideErasedToInterface	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideErasedToPrimitive	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideListVsMutableList	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideUnrelatedInterfaces	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testGenericOverride	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testGenericOverrideSpecialized	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideListVsMutableList	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testCovariantOverrideUnrelatedInterfaces	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testGenericOverride	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testGenericOverrideSpecialized	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testInlineClassInOverriddenReturnTypes	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testKt28483	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testKt31585	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testKt31585	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testKt35234	Failed	PythonExecution	NameError: name 'UNARY_PLUS' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testKt35234a	Failed	PythonExecution	NameError: name 'UNARY_PLUS' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithInlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithNullableInlineClassUpperBoundWithNonNullAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithNullableInlineClassUpperBoundWithNonNullNullableAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithNullableInlineClassUpperBoundWithNonNullNullableAnyNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideNullableInlineClassWithNonNullAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideNullableInlineClassWithNonNullNullableAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideNullableInlineClassWithNonNullNullableAnyNull	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes1a	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes1b	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes2a	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes2b	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testUnrelatedGenerics	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithInlineClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithNullableInlineClassUpperBoundWithNonNullAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithNullableInlineClassUpperBoundWithNonNullNullableAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideGenericWithNullableInlineClassUpperBoundWithNonNullNullableAnyNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideNullableInlineClassWithNonNullAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideNullableInlineClassWithNonNullNullableAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testOverrideNullableInlineClassWithNonNullNullableAnyNull	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes1a	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes1b	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes2a	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testRelatedReturnTypes2b	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$BoxReturnValueOnOverride > testUnrelatedGenerics	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testAllFilesPresentInCallableReferences	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testBoundInlineClassExtensionFun	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testBoundInlineClassExtensionVal	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testBoundInlineClassMemberFun	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testBoundInlineClassMemberVal	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testBoundInlineClassPrimaryVal	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testConstructorWithInlineClassParameters	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testConstructorWithInlineClassParameters	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testEqualsHashCodeToString	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testFunWithInlineClassParameters	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences > testInlineClassExtensionFun	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
@@ -2541,11 +2541,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testAny	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testAnyN	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testInt	Failed	PythonExecution	NameError: name 'Value_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testIntN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testIntN	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testNull	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'value'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testString	Failed	PythonExecution	NameError: name 'Value_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testStringN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$CallableReferences$Let > testStringN	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testAccessPrivateInlineClassCompanionMethod	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testAccessPrivateInlineClassCompanionMethod2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testAccessPrivateInlineClassConstructorFromCompanion	Succeeded		
@@ -2561,36 +2561,36 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testCaptureInlineClassInstanceInLambda2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testCaptureInlineClassInstanceInObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testInlineLambdaInInlineClassFun	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt26858	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt27513	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt26858	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt27513	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt30780	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testLambdaInInlineClassFun	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testObjectInInlineClassFun	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testToPrivateCompanionFun	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testToPrivateCompanionVal	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testAllFilesPresentInDefaultParameterValues	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultConstructorParameterValuesOfInlineClassType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultInterfaceFunParameterValuesOfInlineClassType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultParameterValuesOfInlineClassType	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultParameterValuesOfInlineClassTypeBoxing	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultConstructorParameterValuesOfInlineClassType	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultInterfaceFunParameterValuesOfInlineClassType	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultParameterValuesOfInlineClassType	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultParameterValuesOfInlineClassTypeBoxing	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultValueOfInlineClassTypeInInlineFun	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultValueOfInlineClassTypeInInlineFunInInlineClass	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toString'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testInlineClassFun	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testInlineClassPrimaryConstructor	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testInlineClassPrimaryConstructorWithInlineClassValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testInlineClassPrimaryConstructorWithInlineClassValue	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testInlineClassSecondaryConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testKt26554	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testKt27416	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testAllFilesPresentInFunInterface	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testArgumentIC	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testArgumentResult	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testMangledSamWrappers	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testMangledSamWrappers	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testReturnIC	Failed	PythonExecution	NameError: name 'Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunInterface > testReturnResult	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Assign__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testAllFilesPresentInFunctionNameMangling	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testAnonymousObjectInFunctionWithMangledName	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testExtensionFunctionsDoNotClash	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testFunctionsWithDifferentNullabilityDoNotClash	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testExtensionFunctionsDoNotClash	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testFunctionsWithDifferentNullabilityDoNotClash	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testGenericFunctionsDoNotClash	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testLocalClassInFunctionWithMangledName	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testMangledFunctionsCanBeOverridden	Succeeded		
@@ -2607,24 +2607,24 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testAllFilesPresentInHiddenConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testConstructorReferencedFromOtherFile1	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testConstructorReferencedFromOtherFile2	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testConstructorWithDefaultParameters	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testConstructorWithDefaultParameters	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingSuperConstructorCall	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'string'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingSuperConstructorCallInSecondaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingThisConstructorCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingSuperConstructorCallInSecondaryConstructor	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'string'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingThisConstructorCall	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testEnumClassConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testInnerClassConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testKt28855	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testPrimaryConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testPrivateConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testSealedClassConstructor	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'string'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testSecondaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testSecondaryConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testAllFilesPresentInInlineClassCollection	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testInlineCollectionOfInlineClass	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE_WRONG_RECEIVER: Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testInlineListOfInlineClass	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE_WRONG_RECEIVER: Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testInlineMapOfInlineClass	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: AbstractSet (14,56) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testAllFilesPresentInInterfaceDelegation	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testInterfaceImplementationByDelegation	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testKt38337	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testInterfaceImplementationByDelegation	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testKt38337	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testMemberExtValDelegationWithInlineClassParameterTypes	Failed	PythonExecution	AttributeError: 'FooImpl' object has no attribute 'x'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testMemberExtVarDelegationWithInlineClassParameterTypes	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceDelegation > testMemberFunDelegatedToInlineClassInt	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toString'
@@ -2635,14 +2635,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testComplexGenericMethodWithInlineClassOverride	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testComplexGenericMethodWithInlineClassOverride2	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testComplexGenericMethodWithInlineClassOverride3	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testDefaultInterfaceExtensionFunCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testDefaultInterfaceMethodCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testGenericDefaultInterfaceExtensionFunCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testGenericDefaultInterfaceMethodCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testDefaultInterfaceExtensionFunCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testDefaultInterfaceMethodCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testGenericDefaultInterfaceExtensionFunCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testGenericDefaultInterfaceMethodCall	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testGenericInterfaceMethodCall	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testGenericMethodWithInlineClassOverride	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testInterfaceSuperCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testOverriddenDefaultInterfaceMethodCall	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testInterfaceSuperCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InterfaceMethodCalls > testOverriddenDefaultInterfaceMethodCall	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$JavaInterop > testAllFilesPresentInJavaInterop	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$Jvm8DefaultInterfaceMethods > testAllFilesPresentInJvm8DefaultInterfaceMethods	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$PropertyDelegation > testAllFilesPresentInPropertyDelegation	Succeeded		
@@ -2666,35 +2666,35 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ReturnResult > testTopLevel	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter > testAllFilesPresentInUnboxGenericParameter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAllFilesPresentInFunInterface	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAnyN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIfaceChild	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAnyN	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIface	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIfaceChild	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testNullableResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testResultAny	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: Pair (8,36) in <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAllFilesPresentInLambda	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAnyN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIfaceChild	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAnyN	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIface	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIfaceChild	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testNullableResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testResultAny	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: Pair (6,36) in <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAllFilesPresentInObjectLiteral	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAnyN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIfaceChild	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAnyN	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIface	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIfaceChild	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testNullableResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testResult	Failed	PythonExecution	NameError: name 'kotlin_Result_T_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testResultAny	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: Pair (6,36) in <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testAllFilesPresentInInnerNested	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testCreateNestedClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testCreatedNestedInOuterMember	Succeeded		
@@ -2706,8 +2706,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerImplicitParameter	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerLabeledThis	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerSimple	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerWithDefaultArgument	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerWithDefaultInner	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerWithDefaultArgument	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerWithDefaultInner	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testKt3132	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testKt3927	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testKt5363	Succeeded		
@@ -2720,12 +2720,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testNestedInnerClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testNestedObjects	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testNestedSimple	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testPassingOuterRef	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testPassingOuterRef	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testProtectedNestedClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testAllFilesPresentInSuperConstructorCall	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testDeepInnerHierarchy	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toDouble_0_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testDeepLocalHierarchy	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testInnerExtendsInnerViaSecondaryConstuctor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testDeepLocalHierarchy	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testInnerExtendsInnerViaSecondaryConstuctor	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testInnerExtendsInnerWithProperOuterCapture	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testKt11833_1	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testKt11833_2	Succeeded		
@@ -2733,10 +2733,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testLocalExtendsInner	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testLocalExtendsLocalWithClosure	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testLocalWithClosureExtendsLocalWithClosure	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsClassDefaultArgument	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsClassDefaultArgument	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsClassVararg	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsInner	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsInnerDefaultArgument	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsInnerDefaultArgument	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsInnerOfLocalVarargAndDefault	Failed	PythonExecution	NameError: name 'translateCallArguments_3' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsInnerOfLocalWithCapture	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested$SuperConstructorCall > testObjectExtendsLocalCaptureInSuperCall	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
@@ -2762,8 +2762,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testNonShortCircuitAnd	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testNullPlusString	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testPrefixIncDec	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testRangeFromCollection	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testStringFromCollection	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testRangeFromCollection	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testStringFromCollection	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testThrowable	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testThrowableCallableReference	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testThrowableParamOrder	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
@@ -2784,10 +2784,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testAnonymousObjectInGenericFun	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testAnonymousObjectInsideElvis	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testClassInitializers	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass2	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass3	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testFileClassInitializers	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testFileClassInitializers	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testGenericCompanion	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testHashCodeOnGenericSubstitutedWithPrimitive	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testKt25405	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
@@ -2823,7 +2823,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ja
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$Generics > testKt42824	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$Generics > testKt42825	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$NotNullAssertions > testAllFilesPresentInNotNullAssertions	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$NotNullAssertions > testMapPut	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$NotNullAssertions > testMapPut	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$NotNullAssertions$EnhancedNullability > testAllFilesPresentInEnhancedNullability	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$NotNullAssertions$NullCheckOnLambdaReturnValue > testAllFilesPresentInNullCheckOnLambdaReturnValue	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaInterop$ObjectMethods > testAllFilesPresentInObjectMethods	Succeeded		
@@ -2836,10 +2836,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ja
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaVisibility$ProtectedAndPackage > testAllFilesPresentInProtectedAndPackage	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$JavaVisibility$ProtectedStatic > testAllFilesPresentInProtectedStatic	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testAllFilesPresentInJdk	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testArrayList	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testHashMap	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testIteratingOverHashMap	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testKt1397	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testArrayList	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testHashMap	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testIteratingOverHashMap	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jdk > testKt1397	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jvm8 > testAllFilesPresentInJvm8	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jvm8$Defaults > testAllFilesPresentInDefaults	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Jvm8$Defaults$AllCompatibility > testAllFilesPresentInAllCompatibility	Succeeded		
@@ -2884,15 +2884,15 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$La
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateFalse	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateFalseVar	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateFalseVarChain	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateObjectComp	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateObjectComp2	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateObjectComp	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateObjectComp2	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateTrue	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateTrueVar	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNoOptimization	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testAllFilesPresentInLocalClasses	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testAnonymousObjectInExtension	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testAnonymousObjectInInitializer	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testAnonymousObjectInParameterInitializer	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testAnonymousObjectInParameterInitializer	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testCapturingInDefaultConstructorParameter	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testClosureOfInnerLocalClass	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testClosureOfLambdaInLocalClass	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
@@ -2910,13 +2910,13 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Lo
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt2873	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt3210	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt3389	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt3584	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt3584	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt4174	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt45383	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalClassCaptureExtensionReceiver	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'Outer' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalClassInInitializer	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalClassInParameterInitializer	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalClassInParameterInitializer	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x4__Expr__Assign__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalDataClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalExtendsInnerAndReferencesOuterMember	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalGenericWithTypeParameters	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -2932,10 +2932,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Lo
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testAllFilesPresentInMangling	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testInternal	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testInternalOverride	Failed	PythonExecution	UnboundLocalError: local variable 'invokeOnA' referenced before assignment
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testInternalOverrideSuperCall	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testInternalOverrideSuperCall	Failed	PythonExecution	AttributeError: 'Z' object has no attribute 'field'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testParentheses	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testPublicOverride	Failed	PythonExecution	UnboundLocalError: local variable 'invokeOnA' referenced before assignment
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testPublicOverrideSuperCall	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mangling > testPublicOverrideSuperCall	Failed	PythonExecution	AttributeError: 'Z' object has no attribute 'field'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MixedNamedPosition > testAllFilesPresentInMixedNamedPosition	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MixedNamedPosition > testDefaults	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MixedNamedPosition > testSimple	Failed	PythonExecution	AttributeError: 'float' object has no attribute '__and__'
@@ -2944,7 +2944,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mi
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testAllFilesPresentInMultiDecl	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testComplexInitializer	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testComponent	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testKt9828_hashMap	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testKt9828_hashMap	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testReturnInElvis	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testSimpleVals	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testSimpleValsExtensions	Succeeded		
@@ -2957,16 +2957,16 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mu
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testVarCapturedInLocalFunction	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl > testVarCapturedInObjectLiteral	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testAllFilesPresentInForIterator	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclFor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForComponentExtensions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForComponentMemberExtensions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForComponentMemberExtensionsInExtensionFunction	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForValCaptured	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclFor	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForComponentExtensions	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForComponentMemberExtensions	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForComponentMemberExtensionsInExtensionFunction	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator > testMultiDeclForValCaptured	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testAllFilesPresentInLongIterator	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentExtensions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentExtensionsValCaptured	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentMemberExtensions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentMemberExtensionsInExtensionFunction	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentExtensions	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentExtensionsValCaptured	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentMemberExtensions	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForIterator$LongIterator > testMultiDeclForComponentMemberExtensionsInExtensionFunction	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForRange > testAllFilesPresentInForRange	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForRange > testMultiDeclFor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$MultiDecl$ForRange > testMultiDeclForComponentExtensions	Succeeded		
@@ -3026,14 +3026,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Mu
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testAllFilesPresentInDefaultArguments	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testBothInExpectAndActual	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testBothInExpectAndActual2	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testConstructor	Failed	PythonExecution	TypeError: can only concatenate str (not "int") to str
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testDelegatedExpectedInterface	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail1: [2] object:C.foo(2);]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testDispatchReceiverValue	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testExtensionReceiverValue	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testFunction	Failed	PythonExecution	TypeError: can only concatenate str (not "int") to str
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testFunctionFromOtherModule	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedFromCommonClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedFromExpectedClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedFromCommonClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedFromExpectedClass	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedFromExpectedInterface	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedFromExpectedMethod	Failed	PythonExecution	TypeError: can only concatenate str (not "int") to str
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Multiplatform$DefaultArguments > testInheritedInExpectedDeclarations	Failed	PythonExecution	TypeError: can only concatenate str (not "int") to str
@@ -3104,7 +3104,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ob
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testKt45170	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testKt535	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testKt694	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testLocalFunctionInObjectInitializer_kt4516	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testLocalFunctionInObjectInitializer_kt4516	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testMethodOnObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testNestedDerivedClassCallsProtectedFromCompanion	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testNestedObjectWithSuperclass	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
@@ -3115,7 +3115,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ob
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectLiteral	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectLiteralInClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectLiteralInClosure	Failed	PythonExecution	TypeError: can only concatenate str (not "int") to str
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectVsClassInitialization_kt5291	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectVsClassInitialization_kt5291	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectWithSuperclass	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testObjectWithSuperclassAndTrait	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Objects > testPrivateExtensionFromInitializer_kt4543	Failed	PythonExecution	TypeError: <lambda>() takes 0 positional arguments but 1 was given
@@ -3205,7 +3205,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Op
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testInfixFunctionOverBuiltinMember	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt14201	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt14201_2	Failed	PythonExecution	AttributeError: 'ClassB' object has no attribute 'invoke_1r174_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt14227	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt14227	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt20387	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt39880	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: setOf (8,16) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testKt4152	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
@@ -3217,7 +3217,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Op
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testOperatorSetLambda	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x1__Expr_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testOverloadedSet	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testPlusAssignWithComplexRHS	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'isEmpty_0_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testPlusExplicit	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testPlusExplicit	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testRemAssignmentOperation	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions > testRemOverModOperation	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$OperatorConventions$CompareTo > testAllFilesPresentInCompareTo	Succeeded		
@@ -3245,30 +3245,30 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Pa
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Package > testPackageQualifiedMethod	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Package > testPrivateMembersInImportList	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Package > testPrivateTopLevelPropAndVarInInner	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Package > testReferenceWithTheSameNameAsPackage	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Package > testReferenceWithTheSameNameAsPackage	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ParametersMetadata > testAllFilesPresentInParametersMetadata	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes > testAllFilesPresentInPlatformTypes	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes > testInferenceFlexibleTToNullable	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testAllFilesPresentInPrimitives	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testAssign	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testCompareTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testDec	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testDiv	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testEquals	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testHashCode	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testInc	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testMinus	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testMod	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testNot	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testNotEquals	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testPlus	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testPlusAssign	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testRangeTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testTimes	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testToShort	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testToString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testUnaryMinus	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testUnaryPlus	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testAssign	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testCompareTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testDec	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testDiv	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testEquals	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testHashCode	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testInc	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testMinus	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testMod	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testNot	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testNotEquals	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testPlus	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testPlusAssign	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testRangeTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testTimes	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testToShort	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testToString	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testUnaryMinus	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PlatformTypes$Primitives > testUnaryPlus	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PolymorphicSignature > testAllFilesPresentInPolymorphicSignature	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrimitiveTypes > testAllFilesPresentInPrimitiveTypes	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrimitiveTypes > testComparisonWithNullCallsFun	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
@@ -3366,17 +3366,17 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Pr
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testInline	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testInner	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'foo_0_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testKt4860	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testSecondary	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithArguments	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithDefault	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithLinkedClasses	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testSecondary	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithArguments	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithDefault	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithLinkedClasses	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithLinkedObjects	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithVarargs	Failed	PythonExecution	NameError: name 'translateCallArguments_1' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessToPrivateProperty	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessToPrivateSetter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetter	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetterInObjectLiteral	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetterViaSuper	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetterViaSuper	Failed	PythonExecution	AttributeError: 'B' object has no attribute 'vo'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetterWithIntermediateClass	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAllFilesPresentInProperties	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAugmentedAssignmentsAndIncrements	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
@@ -3495,10 +3495,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForByteProgressionWithIntIncrement	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCharSequenceLengthDecreasedInLoopBody	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCharSequenceLengthIncreasedInLoopBody	Failed	PythonExecution	NameError: name 'undefined' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCharSequenceWithCustomIterator	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCharSequenceWithMultipleGetFunctions	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCharSequenceWithCustomIterator	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCharSequenceWithMultipleGetFunctions	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCustomCharSequence	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCustomIterable	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInCustomIterable	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInDoubleRangeWithCustomIterator	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInFloatRangeWithCustomIterator	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForInRangeLiteralWithMixedTypeBounds	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
@@ -3508,19 +3508,19 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testForNullableIntInRangeWithImplicitReceiver	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testKt37370	Failed	PythonExecution	There was a problem when extracting the contents of STDERR. Details: java.io.IOException: Stream closed
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testKt37370a	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testMultiAssignmentIterationOverIntRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testMultiAssignmentIterationOverIntRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges > testSafeCallRangeTo	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testAllFilesPresentInContains	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testComparisonWithRangeBoundEliminated	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForCollection	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForComparableRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForDownToReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForNullableArgument	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForRangeLiteral	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForRangeLiteralReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForUntil	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForUntilReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForCollection	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForComparableRange	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForDownTo	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForDownToReversed	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForNullableArgument	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForRangeLiteral	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForRangeLiteralReversed	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForUntil	Failed	PythonExecution	NameError: name 'undefined' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testEvaluationOrderForUntilReversed	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testGenericCharInRangeLiteral	Failed	PythonExecution	NameError: name 'kotlin_Char' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testInArray	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testInCharSequence	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
@@ -3547,7 +3547,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testInUntilMaxValue	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testInUntilMinValue	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testInUntilMinValueNonConst	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testKt20106	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testKt20106	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testNullableInPrimitiveRange	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testRangeContainsString	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Contains > testSmartCastOnBothEnds	Failed	KotlinCompilation	java.lang.IllegalStateException: TYPE_MISMATCH: Type mismatch: inferred type is UByte but UInt was expected (15,85) in <path-truncated>
@@ -3606,36 +3606,36 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$EvaluationOrder$Stepped$ForInUntil > testForInUntilStepReversedStepReversed	Failed	PythonExecution	UnboundLocalError: local variable 'step' referenced before assignment
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$EvaluationOrder$Stepped$ForInUntil > testForInUntilStepStep	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'append_uch40_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testAllFilesPresentInExpression	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testEmptyDownto	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOneElementDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOneElementRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOpenRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testEmptyDownto	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOneElementDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOneElementRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOpenRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Expression > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInDownTo > testAllFilesPresentInForInDownTo	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInDownTo > testForIntInDownTo	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInDownTo > testForIntInDownToWithNonConstBounds	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
@@ -3643,7 +3643,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInDownTo > testForLongInDownTo	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInDownTo > testForNullableIntInDownTo	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testAllFilesPresentInForInIndices	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testForInArrayListIndices	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testForInArrayListIndices	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testForInCharSequenceIndices	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testForInCharSequenceTypeParameterIndices	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testForInCollectionImplicitReceiverIndices	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
@@ -3665,20 +3665,20 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testKt43159_ArrayUpperBound	Failed	PythonExecution	TypeError: test_1() takes 1 positional argument but 4 were given
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInIndices > testKt43159_GenericArray	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testAllFilesPresentInForInProgressionWithIndex	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInDownToWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInIndicesWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInRangeToWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInReversedStepWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInReversedWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInStepReversedWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInStepWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInUntilWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInDownToWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInIndicesWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInRangeToWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInReversedStepWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInReversedWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInStepReversedWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInStepWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInUntilWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexBreakAndContinue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexNoIndexOrElementVar	Failed	PythonExecution	NameError: name 'undefined' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexNotDestructured	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexWithDestructuringInLoop	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexWithIndex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexNotDestructured	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexWithDestructuringInLoop	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testForInWithIndexWithIndex	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInProgressionWithIndex > testKt42909	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toString'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInReversed > testAllFilesPresentInForInReversed	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForInReversed > testForInReversedArrayIndices	Failed	PythonExecution	NameError: name 'kotlin_Double' is not defined
@@ -3718,50 +3718,50 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testAllFilesPresentInForWithPossibleOverflow	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToCharMinValue	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToCharMinValueReversed	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToIntMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToIntMinValueReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToIntMinValue	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToIntMinValueReversed	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToLongMinValue	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInDownToLongMinValueReversed	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToCharMaxValue	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToCharMaxValueReversed	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToIntMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToIntMaxValueReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToIntMaxValue	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToIntMaxValueReversed	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToLongMaxValue	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInRangeToLongMaxValueReversed	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$ForWithPossibleOverflow > testForInUntilIntMinValueReversed	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$JavaInterop > testAllFilesPresentInJavaInterop	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$JavaInterop$WithIndex > testAllFilesPresentInWithIndex	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testAllFilesPresentInLiteral	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testEmptyDownto	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOneElementDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOneElementRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOpenRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testEmptyDownto	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOneElementDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOneElementRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOpenRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Literal > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$NullableLoopParameter > testAllFilesPresentInNullableLoopParameter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$NullableLoopParameter > testProgressionExpression	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$NullableLoopParameter > testRangeExpression	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
@@ -3769,409 +3769,409 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped > testAllFilesPresentInStepped	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression > testAllFilesPresentInExpression	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testAllFilesPresentInDownTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testAllFilesPresentInRangeTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testAllFilesPresentInUntil	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Expression$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal > testAllFilesPresentInLiteral	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testAllFilesPresentInDownTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testAllFilesPresentInRangeTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testAllFilesPresentInUntil	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Literal$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned > testAllFilesPresentInUnsigned	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression > testAllFilesPresentInExpression	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testAllFilesPresentInDownTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testAllFilesPresentInRangeTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testAllFilesPresentInUntil	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Expression$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal > testAllFilesPresentInLiteral	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testAllFilesPresentInDownTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMaxValueToMinValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMaxValueToOneStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMaxValueToZeroStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$DownTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testAllFilesPresentInRangeTo	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testOneToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$RangeTo$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testAllFilesPresentInUntil	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testEmptyProgression	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testEmptyProgressionToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testIllegalStepNegative	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testIllegalStepNonConst	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testIllegalStepThenLegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testIllegalStepZero	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testLegalStepThenIllegalStep	Failed	PythonExecution	NameError: name 'jsClass' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testMinValueToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testMixedTypeStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testProgressionToNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testSingleElementStepTwo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepNonConst	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepToOutsideRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until > testZeroToMaxValueStepMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testAllFilesPresentInNestedStep	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepOneThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepThenSameStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSameLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSameLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSameLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSmallerLastThenStepOne	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSameLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$NestedStep > testStepToSmallerLastThenStepToSmallerLast	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testAllFilesPresentInReversed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testReversedThenStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testStepThenReversedThenStep	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Stepped$Unsigned$Literal$Until$Reversed > testStepThenReversedThenStepThenReversed	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned > testAllFilesPresentInUnsigned	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned > testInMixedUnsignedRange	Failed	PythonExecution	NameError: name 'kotlin_UByte' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned > testKt35004	Failed	PythonExecution	NameError: name 'kotlin_ULong' is not defined
@@ -4179,67 +4179,67 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ra
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned > testKt36953_continue	Failed	PythonExecution	There was a problem when extracting the contents of STDERR. Details: java.io.IOException: Stream closed
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned > testOutOfBoundsInMixedContains	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testAllFilesPresentInExpression	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testEmptyDownto	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOneElementDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOneElementRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOpenRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testEmptyDownto	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOneElementDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOneElementRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOpenRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Expression > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testAllFilesPresentInLiteral	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testEmptyDownto	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOneElementDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOneElementRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOpenRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testEmptyDownto	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testInexactToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOneElementDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOneElementRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOpenRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOverflowZeroDownToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testOverflowZeroToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionDownToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMaxValueMinusTwoToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMaxValueToMaxValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMaxValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testProgressionMinValueToMinValue	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedEmptyBackSequence	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedEmptyRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedInexactSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testReversedSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleRangeWithNonConstantEnds	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleSteppedDownTo	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$Literal > testSimpleSteppedRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$NullableLoopParameter > testAllFilesPresentInNullableLoopParameter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$NullableLoopParameter > testProgressionExpression	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ranges$Unsigned$NullableLoopParameter > testRangeExpression	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
@@ -4484,21 +4484,21 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Re
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testDoubleMerge	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testFloatMerge	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testFunctionLiteralAsLastExpressionInBlock	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testGeneric	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testGeneric	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testHashCodeNPE	Failed	PythonExecution	NameError: name 'Object' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testInternalTopLevelOtherPackage	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testIntersectionOfEqualTypes	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt10143	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt10934	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1149	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1149	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1172	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt13381	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt14447	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt15196	Failed	PythonExecution	NameError: name 'Array' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1528	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1619Test	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1619Test	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1779	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1800	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1800	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt1845	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt18779	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt2017	Failed	PythonExecution	UnboundLocalError: local variable 'sorted' referenced before assignment
@@ -4506,14 +4506,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Re
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt2210	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt2246	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt24913	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt2495Test	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt2495Test	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt2509	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt3107	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt32949	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt33638	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt3421	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt344	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt3442	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt3442	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt3587	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt35914	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt3850	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
@@ -4525,11 +4525,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Re
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt5395	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt5786_privateWithDefault	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt5953	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt6153	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt6153	Failed	PythonExecution	NameError: name 'undefined' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt6434	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt6434_2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt7401	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt789	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt789	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testKt998	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testLambdaAsLastExpressionInLambda	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Regressions > testLambdaPostponeConstruction	Succeeded		
@@ -4584,8 +4584,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sa
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Adapters > testAllFilesPresentInAdapters	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Adapters$Operators > testAllFilesPresentInOperators	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Constructors > testAllFilesPresentInConstructors	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Constructors > testComparator	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Constructors > testNonLiteralComparator	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Constructors > testComparator	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Constructors > testNonLiteralComparator	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Constructors > testSameWrapperClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sam$Equality > testAllFilesPresentInEquality	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SameFileInSourceAndDependencies > testAllFilesPresentInSameFileInSourceAndDependencies	Succeeded		
@@ -4599,43 +4599,43 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sa
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SameFileInSourceAndDependencies > testPropertyDeclaration	Failed	BoxTestsFailure	java.lang.IllegalStateException: Can't find compiled module for dependency <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Script > testAllFilesPresentInScript	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testAllFilesPresentInSealed	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testDelegatingConstructor	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testDelegatingConstructor	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testMultipleFiles_enabled	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testObjects	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testSealedInSameFile	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testSealedInSameFile	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testSimple	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAccessToCompanion	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAccessToNestedObject	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAccessToCompanion	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAccessToNestedObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAllFilesPresentInSecondaryConstructors	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicNoPrimaryManySinks	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicNoPrimaryOneSink	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicPrimary	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromLocalSubClass	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromPrimaryWithNamedArgs	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromPrimaryWithOptionalArgs	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromSubClass	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testClashingDefaultConstructors	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDataClasses	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicNoPrimaryManySinks	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicNoPrimaryOneSink	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicPrimary	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromLocalSubClass	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromPrimaryWithNamedArgs	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail: None]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromPrimaryWithOptionalArgs	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail: None]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testCallFromSubClass	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testClashingDefaultConstructors	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toString'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDataClasses	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDefaultArgs	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDefaultParametersNotDuplicated	Failed	PythonExecution	SyntaxError: invalid syntax
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegateWithComplexExpression	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegatedThisWithLambda	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegateWithComplexExpression	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegatedThisWithLambda	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegationWithPrimary	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testEnums	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testFieldInitializerOptimization	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testFieldInitializerOptimization_inlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testGenerics	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInlineIntoTwoConstructors	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInnerClasses	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInnerClassesInheritance	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testFieldInitializerOptimization	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'data'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testFieldInitializerOptimization_inlineClass	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testGenerics	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail3: None]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInlineIntoTwoConstructors	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInnerClasses	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInnerClassesInheritance	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testLocalClasses	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testSuperCallPrimary	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testSuperCallSecondary	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testSuperCallPrimary	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testSuperCallSecondary	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testVarargs	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithNonLocalReturn	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithReturn	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithReturnUnit	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithoutPrimarySimple	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithNonLocalReturn	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithReturn	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithReturnUnit	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testWithoutPrimarySimple	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Smap > testAllFilesPresentInSmap	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SmartCasts > testAllFilesPresentInSmartCasts	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SmartCasts > testComplexExplicitReceiver	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -4670,7 +4670,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sp
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testEntrySetSOE	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testEnumAsOrdinaled	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testExceptionCause	Failed	PythonExecution	NameError: name '_undefined' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testExplicitSuperCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testExplicitSuperCall	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testIrrelevantRemoveAtOverride	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail 1]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testMaps	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testNoSpecialBridgeInSuperClass	Succeeded		
@@ -4681,7 +4681,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sp
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testRemoveSetInt	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testThrowable	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testThrowableCause	Failed	PythonExecution	NameError: name '_undefined' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testThrowableComplex	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testThrowableComplex	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testThrowableImpl	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testThrowableImplWithSecondaryConstructor	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SpecialBuiltins > testValuesInsideEnum	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
@@ -4724,12 +4724,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$St
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Strings > testSimpleStringPlus	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Strings > testSingleConcatNullable	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Strings > testStringBuilderAppend	Failed	PythonExecution	TypeError: can only concatenate str (not "A") to str
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Strings > testStringPlusOnlyWorksOnString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Strings > testStringPlusOnlyWorksOnString	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Strings > testStringPlusOverride	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testAllFilesPresentInSuper	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testBasicmethodSuperClass	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testBasicmethodSuperClass	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testBasicmethodSuperTrait	Failed	PythonExecution	RecursionError: maximum recursion depth exceeded
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testBasicproperty	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testBasicproperty	Failed	PythonExecution	AttributeError: 'N' object has no attribute 'b'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testEnclosedFun	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test1 fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testEnclosedVar	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test6 fail]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super > testInnerClassLabeledSuper	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test1 A.foo]>
@@ -4760,14 +4760,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Su
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testAllFilesPresentInSuperConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testKt13846	Failed	PythonExecution	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testKt17464_arrayOf	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testKt17464_linkedMapOf	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testKt17464_linkedMapOf	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testKt18356	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testKt18356_2	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testObjectExtendsInner	Failed	PythonExecution	NameError: name 'translateCallArguments_3' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testObjectExtendsLocalInner	Failed	PythonExecution	NameError: name 'translateCallArguments_3' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Synchronized > testAllFilesPresentInSynchronized	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForAbstractProtected	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForGenericConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForGenericConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForGenericMethod	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForGenericMethodWithDefaults	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForProtected	Succeeded		
@@ -4794,7 +4794,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sy
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticExtensions > testAllFilesPresentInSyntheticExtensions	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Throws > testAllFilesPresentInThrows	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ToArray > testAllFilesPresentInToArray	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ToArray > testKt3177_toTypedArray	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ToArray > testKt3177_toTypedArray	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ToArray > testReturnToTypedArray	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ToArray > testToTypedArray	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$TopLevelPrivate > testAllFilesPresentInTopLevelPrivate	Succeeded		
@@ -4861,7 +4861,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ty
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testInnerClassTypeAliasConstructorInSupertypes	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testKt15109	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testKt45308	Failed	BoxTestsFailure	java.lang.IllegalStateException: Can't find compiled module for dependency <path-truncated>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testObjectLiteralConstructor	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[<compiled_module.SendBuffered object at [address]>]>
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testObjectLiteralConstructor	Failed	PythonExecution	AttributeError: '_no_name_provided__9' object has no attribute 'node'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testPrivateInKlib	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testSimple	Failed	PythonExecution	TypeError: 'NoneType' object is not callable
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testTypeAliasAsBareType	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
@@ -4874,7 +4874,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ty
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testTypeAliasInAnonymousObjectType	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testTypeAliasObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testTypeAliasObjectCallable	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testTypeAliasSecondaryConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Typealias > testTypeAliasSecondaryConstructor	Failed	PythonExecution	AttributeError: 'int' object has no attribute 'toString'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnaryOp > testAllFilesPresentInUnaryOp	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnaryOp > testCall	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnaryOp > testCallNullable	Succeeded		
@@ -4899,7 +4899,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Un
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testBoxedUnsignedEqualsZero	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testCheckBasicUnsignedLiterals	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testDefaultArguments	Failed	PythonExecution	NameError: name 'kotlin_UByte' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testEqualsImplForInlineClassWrappingNullableInlineClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testEqualsImplForInlineClassWrappingNullableInlineClass	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testForEachIndexedInListOfUInts	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testForInUnsignedDownTo	Failed	PythonExecution	NameError: name 'kotlin_UInt' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testForInUnsignedProgression	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'first'
@@ -4924,7 +4924,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Un
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedIntRemainder	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedIntToString	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedLiteralsForMaxLongValue	Failed	PythonExecution	NameError: name 'kotlin_ULong' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedLiteralsInApiVersion14	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedLiteralsInApiVersion14	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedLiteralsWithSignedOverflow	Failed	PythonExecution	NameError: name 'kotlin_UByte' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedLongCompare	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'data'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$UnsignedTypes > testUnsignedLongDivide	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'data'
@@ -4943,12 +4943,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Va
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testDoNotCopyImmediatelyCreatedArrays	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testEvaluationOrder	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Expr__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt1978	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt37715	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt37715	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt37779	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt581	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt581	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt6192	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testKt796_797	Failed	PythonExecution	NameError: name 'INVOKE' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testReferenceToContainsFromVarargParameter	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testReferenceToContainsFromVarargParameter	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testSingleAssignmentToVarargsInFunction	Failed	PythonExecution	TypeError: can only concatenate str (not "int") to str
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testSpreadCopiesArray	Failed	KotlinCompilation	java.lang.IllegalStateException: TOO_MANY_ARGUMENTS: Too many arguments for public fun <T> assertEquals(a: T, b: T): Unit defined in kotlin.test (25,34) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Vararg > testVarargInFunParam	Failed	KotlinCompilation	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
@@ -4965,12 +4965,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Wh
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testImplicitExhaustiveAndReturn	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testInferredTypeParameters	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testIntegralWhenWithNoInlinedConstants	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testIs	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testIs	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testKt2457	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testKt2466	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testKt45081	Failed	KotlinCompilation	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: it (6,28) in <path-truncated>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testKt5307	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testKt5448	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testKt5448	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testLongInRange	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testMatchNotNullAgainstNullable	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testMultipleEntries	Succeeded		
@@ -4981,7 +4981,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Wh
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testNoElseInStatement	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testNoElseNoMatch	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testNullableWhen	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testRange	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testRange	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testSealedWhenInitialization	Failed	PythonExecution	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testSwitchBreakNoLabel	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail1]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testSwitchOptimizationDense	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
@@ -4994,7 +4994,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Wh
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testSwitchOptimizationUnordered	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testSwitchOptimizationWithGap	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testTypeDisjunction	Failed	PythonExecution	NameError: name 'js' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testWhenArgumentIsEvaluatedOnlyOnce	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testWhenArgumentIsEvaluatedOnlyOnce	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When > testWhenSafeCallSubjectEvaluatedOnce	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$EnumOptimization > testAllFilesPresentInEnumOptimization	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$EnumOptimization > testBigEnum	Succeeded		
@@ -5029,7 +5029,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Wh
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testCaptureSubjectVariable	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testDenseIntSwitchWithSubjectVariable	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testEqualityWithSubjectVariable	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail: None]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testIeee754Equality	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testIeee754Equality	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testIeee754EqualityWithSmartCast	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testIsCheckOnSubjectVariable	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testKt27161	Succeeded		
@@ -5040,12 +5040,12 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Wh
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testRangeCheckOnSubjectVariable	Failed	PythonExecution	TypeError: '<=' not supported between instances of 'int' and 'NoneType'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testSparseIntSwitchWithSubjectVariable	Failed	PythonExecution	NameError: name 'kotlin_Int' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testSubjectExpressionIsEvaluatedOnce	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testWhenByEnum	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testWhenByNullableEnum	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testWhenByEnum	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testWhenByNullableEnum	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$When$WhenSubjectVariable > testWhenByString	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated > testAllFilesPresentInBoxInline	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testAllFilesPresentInAnonymousObject	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testAnonymousObjectInDefault	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testAnonymousObjectInDefault	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Expr__Assign__Return_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testAnonymousObjectOnCallSite	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testAnonymousObjectOnCallSiteSuperParams	Failed	PythonExecution	TypeError: can only concatenate str (not "NoneType") to str
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testAnonymousObjectOnDeclarationSite	Succeeded		
@@ -5083,8 +5083,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt19723	Failed	PythonExecution	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionExpressionImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt34656	Failed	PythonExecution	AttributeError: 'NoneType' object has no attribute 'call_0_k_'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt38197	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt42815	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt42815_delegated	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt42815	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt42815_delegated	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt6007	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt6552	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[O]K> but was:<[K]K>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt8133	Succeeded		
@@ -5097,7 +5097,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSafeCall	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSafeCall_2	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSharedFromCrossinline	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSuperConstructorWithObjectParameter	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSuperConstructorWithObjectParameter	Failed	PythonExecution	AttributeError: '_no_name_provided__1_1' object has no attribute 'x'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testTypeInfo	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testWithInlineMethod	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject$EnumWhen > testAllFilesPresentInEnumWhen	Succeeded		
@@ -5167,7 +5167,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testInnerGenericConstuctor	Failed	PythonExecution	NameError: name 'test_Inner_kotlin_String_kotlin_String_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testIntrinsic	Failed	PythonExecution	NameError: name 'kotlin_Any_' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testKt15449	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x1__Expr_' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testKt15751_2	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testKt15751_2	Failed	PythonExecution	NameError: name 'EXCLEQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testKt16411	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testKt35101	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$CallableReference > testPropertyIntrinsic	Failed	PythonExecution	NameError: name 'jsClass' is not defined
@@ -5238,7 +5238,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testCrossinlineCallableReference	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testDefiniteLongValInitialization	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testDefiniteNestedValInitialization	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testDefiniteValInitInInitializer	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testDefiniteValInitInInitializer	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testDefiniteValInitialization	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testExactlyOnceCrossinline	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testExactlyOnceCrossinline2	Failed	PythonExecution	NameError: name 'visitExpressionFunctionBodyStatements_x2__Assign__Expr_' is not defined
@@ -5248,11 +5248,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testPropertyInitialization	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testValInitializationAndUsageInNestedLambda	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > test33Parameters	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > test33ParametersInConstructor	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > test33ParametersInConstructor	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testAllFilesPresentInDefaultValues	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultInExtension	Failed	PythonExecution	TypeError: can only concatenate str (not "NoneType") to str
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultMethod	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultMethodInClass	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultMethodInClass	Failed	PythonExecution	NameError: name 'EQEQ' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultParamRemapping	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testInlineInDefaultParameter	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testInlineLambdaInNoInlineDefault	Succeeded		
@@ -5341,13 +5341,13 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testAllFilesPresentInEnum	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testKt10569	Failed	PythonExecution	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testKt18254	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOf	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfCapturedType	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChain	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChainCapturedType	Succeeded		
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOf	Failed	PythonExecution	AttributeError: 'Z' object has no attribute 'name'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfCapturedType	Failed	PythonExecution	AttributeError: 'Z' object has no attribute 'name'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChain	Failed	PythonExecution	AttributeError: 'Z' object has no attribute 'name'
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChainCapturedType	Failed	PythonExecution	AttributeError: 'Z' object has no attribute 'name'
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfNonReified	Failed	AssertionFailed	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValues	Failed	PythonExecution	NameError: name 'kotlin_CharSequence' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValuesAsArray	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValuesAsArray	Failed	PythonExecution	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValuesCapturedType	Failed	PythonExecution	NameError: name 'kotlin_CharSequence' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValuesChain	Failed	PythonExecution	NameError: name 'kotlin_CharSequence' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValuesChainCapturedType	Failed	PythonExecution	NameError: name 'kotlin_CharSequence' is not defined
@@ -5364,26 +5364,26 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses > testWithReturnTypeManglingVal	Failed	PythonExecution	NameError: name 'test_S' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter > testAllFilesPresentInUnboxGenericParameter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAllFilesPresentInFunInterface	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAnyN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIfaceChild	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testAnyN	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIface	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testIfaceChild	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$FunInterface > testString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAllFilesPresentInLambda	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAnyN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIfaceChild	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testAnyN	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIface	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testIfaceChild	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$Lambda > testString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAllFilesPresentInObjectLiteral	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAny	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAnyN	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIface	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIfaceChild	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testPrimitive	Failed	PythonExecution	NameError: name 'Object_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testString	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAny	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testAnyN	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIface	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testIfaceChild	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testPrimitive	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testString	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InnerClasses > testAllFilesPresentInInnerClasses	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$InnerClasses > testCaptureThisAndOuter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Invokedynamic > testAllFilesPresentInInvokedynamic	Succeeded		
@@ -5509,11 +5509,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$ExceptionTable > testSimpleThrow	Failed	PythonExecution	UnboundLocalError: local variable 'test0' referenced before assignment
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$ExceptionTable > testSynchonized	Failed	PythonExecution	UnboundLocalError: local variable 'call' referenced before assignment
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$ExceptionTable > testThrowInFinally	Failed	PythonExecution	UnboundLocalError: local variable 'test0' referenced before assignment
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$ExceptionTable > testTryCatchInFinally	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$ExceptionTable > testTryCatchInFinally	Failed	PythonExecution	NameError: name 'kotlin_String' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$Variables > testAllFilesPresentInVariables	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$NonLocalReturns$TryFinally$Variables > testKt7792	Failed	PythonExecution	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Optimizations > testAllFilesPresentInOptimizations	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Optimizations > testKt20844	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Optimizations > testKt20844	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Private > testAccessorForConst	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Private > testAccessorStability	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Private > testAccessorStabilityInClass	Succeeded		
@@ -5585,7 +5585,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testExtensionLambda	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testFunImportedFromObject	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testInlineCallInInlineLambda	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testKt17431	Failed	PythonExecution	NameError: name 'Object_create' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testKt17431	Failed	PythonExecution	NameError: name 'self' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testKt28547	Failed	PythonExecution	NameError: name 'js' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testKt28547_2	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Simple > testParams	Succeeded		
@@ -5695,28 +5695,28 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testInlineSuspendOfSuspend	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testKt26658	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testMaxStackWithCrossinline	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testMultipleLocals	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testMultipleSuspensionPoints	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testMultipleLocals	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testMultipleSuspensionPoints	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testNonLocalReturn	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testNonSuspendCrossinline	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testReturnValue	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTryCatchReceiver	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTryCatchStackTransform	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTwiceRegeneratedAnonymousObject	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTwiceRegeneratedSuspendLambda	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTryCatchStackTransform	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTwiceRegeneratedAnonymousObject	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend > testTwiceRegeneratedSuspendLambda	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testAllFilesPresentInCallableReference	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testIsAsReified	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testIsAsReified2	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testNonTailCall	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testNonTailCall	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testSimple	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$CallableReference > testUnitReturn	Failed	PythonExecution	SyntaxError: invalid syntax
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testAllFilesPresentInDefaultParameter	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultInlineLambda	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultInlineReference	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueCrossinline	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueInClass	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueInline	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueInlineFromMultiFileFacade	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueCrossinline	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueInClass	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueInline	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$DefaultParameter > testDefaultValueInlineFromMultiFileFacade	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$InlineClass > testAllFilesPresentInInlineClass	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$InlineClass > testReturnUnboxedDirect	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$InlineClass > testReturnUnboxedResume	Failed	PythonExecution	NameError: name '_sharedBox_create' is not defined
@@ -5724,14 +5724,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$InlineUsedAsNoinline > testInlineOnly	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$InlineUsedAsNoinline > testSimpleNamed	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testAllFilesPresentInReceiver	Succeeded		
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineOrdinaryOfCrossinlineSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineOrdinaryOfNoinlineSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfCrossinlineOrdinary	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfCrossinlineSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfNoinlineOrdinary	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfNoinlineSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfOrdinary	Failed	PythonExecution	NameError: name 'self' is not defined
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfSuspend	Failed	PythonExecution	NameError: name 'self' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineOrdinaryOfCrossinlineSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineOrdinaryOfNoinlineSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfCrossinlineOrdinary	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfCrossinlineSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfNoinlineOrdinary	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfNoinlineSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfOrdinary	Failed	PythonExecution	NameError: name 'jsClass' is not defined
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$Receiver > testInlineSuspendOfSuspend	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$StateMachine > testAllFilesPresentInStateMachine	Succeeded		
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$StateMachine > testCrossingCoroutineBoundaries	Failed	PythonExecution	NameError: name 'jsClass' is not defined
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Suspend$StateMachine > testIndependentInline	Failed	PythonExecution	NameError: name 'jsClass' is not defined

--- a/python/experiments/failed-tests.txt
+++ b/python/experiments/failed-tests.txt
@@ -429,7 +429,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testInnerClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1018 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1247 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1345 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1538 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1578 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt1721 FAILED
@@ -457,7 +456,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt5347 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt6136 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt633 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt6816 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testKt8011 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadBinaryOperator FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testOverloadPlusAssign FAILED
@@ -469,6 +467,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPrivateToThis FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPropertyDelegation FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testPropertyInInitializer FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSelfcreate FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSimpleBox FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSuperConstructorCallWithComplexArg FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testTypedDelegation FAILED
@@ -476,6 +475,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInDerived FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInDerivedLabeled FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testInstantiateInSameClass FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testProperOuter FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testProperSuperLinking FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testAnonymousObjectAsLastExpressionInLambda FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures > testCaptureExtensionReceiver FAILED
@@ -500,12 +500,14 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testConstructorParameterCapturedInLambdaInLocalClass2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt13454 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt14148 FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt4174 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt4174a FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInAnonymousObjectInLocalClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInAnonymousObjectInLocalClass2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInLambdaInInnerClassInLocalClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalCapturedInLambdaInLocalClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testLocalFunctionCapturedInLambda FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterAndLocalCapturedInLocalClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedAsImplicitThisInBoundReference FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInFunctionLiteral FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInInlineLambda FAILED
@@ -521,6 +523,8 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Cl
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInObject2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInPrimaryConstructorDefaultParameter FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterCapturedInSecondaryConstructorDefaultParameter FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterEnumEntryCapturedInLambdaInInnerClass FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure1 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testReferenceToCapturedVariablesInMultipleLambdas FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureOuterProperty > testInPropertyFromSuperClass FAILED
@@ -1206,7 +1210,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Da
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Copy > testWithSecondaryConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testGenericarray FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testIntarray FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$Equals > testSameinstance FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$HashCode > testByte FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$HashCode > testChar FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DataClasses$HashCode > testDouble FAILED
@@ -1237,16 +1240,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments > testSimpleFromOtherFile FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments > testUseNextParamInLambda FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments > testUseThisInLambda FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs1 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs1InnerClass FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDefArgs2 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testDoubleDefArgs1InnerClass FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnum FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithOneDefArg FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithTwoDefArgs FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testEnumWithTwoDoubleDefArgs FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testInnerClass32Args FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt2852 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt30517 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testKt3060 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Constructor > testObjectExpressionDelegatingToSecondaryConstructor FAILED
@@ -1273,8 +1266,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Function > testMixingNamedAndPositioned FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Function > testTrait FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testMemberFunction FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testPrimaryConstructor FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Private > testSecondaryConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt2789 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt9428 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DefaultArguments$Signature > testKt9924 FAILED
@@ -1365,7 +1356,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$De
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testPropertyMetadata FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$DelegatedProperty$ProvideDelegate > testProvideDelegateByExtensionFunction FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testDelegationDifferentModule FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testDelegationWithPrivateConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testGenericProperty FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testKt30102_comparable FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Delegation > testViaTypeAlias FAILED
@@ -1395,7 +1385,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$El
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Elvis > testOfNonNullableResultType FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testCompanionAccessingEnumValue FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testDeepInnerClassInEnumEntryClass2 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEmptyConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEmptyEnumValuesValueOf FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEnumCompanionInit FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testEnumConstructorParameterClashWithDefaults FAILED
@@ -1417,7 +1406,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$En
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testKt7257_boundReference1 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testKt7257_boundReference2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testKt7257_boundReferenceWithImplicitReceiver FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testManyDefaultParameters FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testObjectInEnum FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testOrdinal FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testSortEnumEntries FAILED
@@ -1425,11 +1413,9 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$En
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testToString FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testValueof FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum > testWhenInObject FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testConstructorWithDefaultArguments FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testConstructorWithVararg FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testEntryClassConstructorWithDefaultArguments FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testEntryClassConstructorWithVarargs FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testSecondaryConstructorWithDefaultArguments FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Enum$DefaultCtor > testSecondaryConstructorWithVararg FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Evaluate > testKt9443 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$ExclExcl > testGenericNull FAILED
@@ -1516,7 +1502,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Fu
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testFunctionNtoString FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testFunctionNtoStringNoReflect FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt1038 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2270 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2280 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2481 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Functions > testKt2929 FAILED
@@ -1840,7 +1825,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testAccessPrivateInlineClassConstructorFromLambda FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt26858 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$ContextsAndAccessors > testKt27513 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultConstructorParameterValuesOfInlineClassType FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultInterfaceFunParameterValuesOfInlineClassType FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultParameterValuesOfInlineClassType FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$DefaultParameterValues > testDefaultParameterValuesOfInlineClassTypeBoxing FAILED
@@ -1858,13 +1842,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testFunctionsWithDifferentNullabilityDoNotClash FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testReflectionForFunctionWithMangledName FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$FunctionNameMangling > testReflectionForPropertyOfInlineClassType FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testConstructorWithDefaultParameters FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingSuperConstructorCall FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingSuperConstructorCallInSecondaryConstructor FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testDelegatingThisConstructorCall FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testKt28855 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testSealedClassConstructor FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$HiddenConstructor > testSecondaryConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testInlineCollectionOfInlineClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testInlineListOfInlineClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$InlineClassCollection > testInlineMapOfInlineClass FAILED
@@ -1930,8 +1911,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InlineClasses$UnboxGenericParameter$ObjectLiteral > testString FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testExtenderNestedClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerImplicitParameter FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerWithDefaultArgument FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testInnerWithDefaultInner FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testKt3927 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testNestedEnumConstant FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$InnerNested > testPassingOuterRef FAILED
@@ -1972,7 +1951,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$In
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Intrinsics > testTrimMarginWithBlankString FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testAnonymousObjectInForLoopIteratorAndBody FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testEnumClass2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testFileClassInitializers FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir > testKt25405 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Ir$ClosureConversion > testClosureConversion2 FAILED
@@ -1999,7 +1977,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$La
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateObjectComp FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNegateObjectComp2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LazyCodegen$Optimizations > testNoOptimization FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testAnonymousObjectInParameterInitializer FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testCapturingInDefaultConstructorParameter FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testClosureOfInnerLocalClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testClosureOfLambdaInLocalClass FAILED
@@ -2013,7 +1990,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Lo
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt2700 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt2873 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt3210 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt3584 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt4174 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testKt45383 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$LocalClasses > testLocalClassCaptureExtensionReceiver FAILED
@@ -2277,10 +2253,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Pr
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrimitiveTypes$EqualityWithObject$Generated > testPrimitiveEqObjectLong FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrimitiveTypes$EqualityWithObject$Generated > testPrimitiveEqObjectShort FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testInner FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testSecondary FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithArguments FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithDefault FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithLinkedClasses FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$PrivateConstructors > testWithVarargs FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetter FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Properties > testAccessorForProtectedPropertyWithPrivateSetterInObjectLiteral FAILED
@@ -3116,10 +3088,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sa
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SameFileInSourceAndDependencies > testPropertyDeclaration FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testDelegatingConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testMultipleFiles_enabled FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testSealedInSameFile FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Sealed > testSimple FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAccessToCompanion FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testAccessToNestedObject FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicNoPrimaryManySinks FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicNoPrimaryOneSink FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testBasicPrimary FAILED
@@ -3132,13 +3101,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Se
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDefaultArgs FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDefaultParametersNotDuplicated FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegateWithComplexExpression FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegatedThisWithLambda FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testDelegationWithPrimary FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testEnums FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testFieldInitializerOptimization FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testFieldInitializerOptimization_inlineClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testGenerics FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInlineIntoTwoConstructors FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInnerClasses FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testInnerClassesInheritance FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SecondaryConstructors > testLocalClasses FAILED
@@ -3244,7 +3211,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Su
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testObjectExtendsInner FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Super$SuperConstructor > testObjectExtendsLocalInner FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForAbstractProtected FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForGenericConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForGenericMethodWithDefaults FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForProtectedInvokeVirtual FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$SyntheticAccessors > testAccessorForProtectedPropertyReference FAILED
@@ -3424,7 +3390,6 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt19723 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt34656 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt38197 FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt42815 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt42815_delegated FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt6552 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testKt9591 FAILED
@@ -3434,6 +3399,7 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSafeCall FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSafeCall_2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSharedFromCrossinline FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSuperConstructorWithObjectParameter FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testTypeInfo FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject$EnumWhen > testCallSite FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject$EnumWhen > testDeclSite FAILED
@@ -3514,13 +3480,11 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$ComplexStack > testSpillConstructorArgumentsAndInlineLambdaParameter FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testComplexInitializerWithStackTransformation FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testCrossinlineCallableReference FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testDefiniteValInitInInitializer FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testExactlyOnceCrossinline FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testExactlyOnceCrossinline2 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testExactlyOnceNoinline FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Contracts > testNonLocalReturnWithCycle FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > test33Parameters FAILED
-org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > test33ParametersInConstructor FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultInExtension FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testDefaultMethodInClass FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DefaultValues > testInlineInDefaultParameter FAILED
@@ -3565,6 +3529,10 @@ org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$DelegatedProperty > testLocalInLambda FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testKt10569 FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testKt18254 FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOf FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfCapturedType FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChain FAILED
+org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChainCapturedType FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfNonReified FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValues FAILED
 org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValuesAsArray FAILED

--- a/python/experiments/failure-count.tsv
+++ b/python/experiments/failure-count.tsv
@@ -1,49 +1,50 @@
-880	NameError: name 'Object_create' is not defined
+520	NameError: name 'kotlin_Array_kotlin_Any__' is not defined
 408	NameError: name '_sharedBox_create' is not defined
-319	NameError: name 'jsClass' is not defined
+403	NameError: name 'jsClass' is not defined
+219	NameError: name 'self' is not defined
 177	NameError: name 'js' is not defined
 170	NameError: name 'visitTry_org_jetbrains_kotlin_ir_expressions_impl_IrTryImpl' is not defined
 135	NameError: name 'visitExpression_other_org_jetbrains_kotlin_ir_expressions_impl_IrFunctionReferenceImpl' is not defined
-108	NameError: name 'self' is not defined
-80	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
+84	org.junit.ComparisonFailure: expected:<[OK]> but was:<[None]>
 73	java.lang.IllegalStateException: Can't find compiled module for dependency <path-truncated>
-69	NameError: name 'Array' is not defined
+72	NameError: name 'undefined' is not defined
+70	NameError: name 'Array' is not defined
 67	NameError: name 'kotlin_Any_' is not defined
-65	AttributeError: 'int' object has no attribute 'data'
-48	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
+66	AttributeError: 'int' object has no attribute 'data'
+47	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_jsInstanceOf_visibility_public_modality_FINAL_____arg0_kotlin_Any___arg1_kotlin_Any___returnType_kotlin_Boolean' is not defined
+46	NameError: name 'EQEQ' is not defined
+45	NameError: name 'kotlin_String' is not defined
 44	NameError: name 'kotlin_Int' is not defined
-43	NameError: name 'EQEQ' is not defined
-42	NameError: name 'kotlin_String' is not defined
-41	TypeError: 'NoneType' object is not callable
+41	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+40	TypeError: 'NoneType' object is not callable
 39	NameError: name 'kotlin_UInt' is not defined
 35	AttributeError: 'int' object has no attribute 'compareTo_wiekkq_k_'
 35	SyntaxError: invalid syntax
-35	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 34	NameError: name 'kotlin_Double' is not defined
 31	AttributeError: 'NoneType' object has no attribute 'append_uch40_k_'
-30	NameError: name 'INVOKE' is not defined
+31	NameError: name 'INVOKE' is not defined
+25	NameError: name 'EXCLEQEQ' is not defined
 25	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail]>
 23	kotlin.NotImplementedError: An operation is not implemented: IrSpreadElementImpl is not supported yet here
-19	RecursionError: maximum recursion depth exceeded
 19	TypeError: <lambda>() takes 0 positional arguments but 1 was given
 19	UnboundLocalError: local variable 'test1' referenced before assignment
 18	TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
 17	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int32Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
+17	RecursionError: maximum recursion depth exceeded
 16	There was a problem when extracting the contents of STDERR. Details: java.io.IOException: Stream closed
 15	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail 0]>
 14	NameError: name 'kotlin_Result_T_' is not defined
-13	TypeError: can only concatenate str (not "int") to str
-12	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
+14	TypeError: can only concatenate str (not "int") to str
+14	TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
 12	UnboundLocalError: local variable 'test0' referenced before assignment
+10	AttributeError: 'int' object has no attribute 'toString'
 10	ImportError: cannot import name 'box' from 'compiled_module' <path-truncated>)
 10	NameError: name 'visitExpressionFunctionBodyStatements_x2__Expr__Return_' is not defined
 9	AttributeError: 'NoneType' object has no attribute 'invoke_0_k_'
 9	NameError: name 'kotlin_CharSequence' is not defined
-9	NameError: name 'undefined' is not defined
 9	NameError: name 'visitExpressionFunctionBodyStatements_x1__Expr_' is not defined
 9	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrCallImpl' is not defined
 8	AttributeError: 'NoneType' object has no attribute 'foo_0_k_'
-8	AttributeError: 'int' object has no attribute 'toString'
 8	NameError: name 'visitExpressionFunctionBodyStatements_x2__Assign__Expr_' is not defined
 8	java.lang.IllegalArgumentException: List has more than one element.
 8	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail]>
@@ -67,6 +68,7 @@
 5	TypeError: __init__() takes 1 positional argument but 2 were given
 5	TypeError: can only concatenate str (not "NoneType") to str
 4	AttributeError: 'Companion_20' object has no attribute 'getO_0_k_'
+4	AttributeError: 'Z' object has no attribute 'name'
 4	NameError: name 'Infinity' is not defined
 4	NameError: name 'Result_T_' is not defined
 4	NameError: name 'T' is not defined
@@ -81,15 +83,16 @@
 4	kotlin.UninitializedPropertyAccessException: lateinit property parent has not been initialized
 4	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail 1]>
 4	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail: None]>
+4	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail: None]>
 4	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test1 A.foo]>
 3	AttributeError: 'Foo' object has no attribute 'bar'
 3	AttributeError: 'NoneType' object has no attribute 'getValue_d8h4ck_k_'
 3	AttributeError: 'NoneType' object has no attribute 'iterator_0_k_'
+3	AttributeError: 'NoneType' object has no attribute 'string'
 3	AttributeError: 'float' object has no attribute '__and__'
 3	AttributeError: 'int' object has no attribute 'toDouble_0_k_'
 3	MemoryError
 3	NameError: name 'Foo_T_' is not defined
-3	NameError: name '_undefined' is not defined
 3	NameError: name 'kotlin_Any' is not defined
 3	NameError: name 'kotlin_Double_' is not defined
 3	NameError: name 'translateCallArguments_1' is not defined
@@ -103,14 +106,16 @@
 3	UnboundLocalError: local variable 'step' referenced before assignment
 3	org.junit.ComparisonFailure: expected:<[OK]> but was:<[<compiled_module.A object at [address]>]>
 3	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail #1]>
-3	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail #2]>
+2	AttributeError: 'Local' object has no attribute 'fn'
+2	AttributeError: 'N' object has no attribute 'b'
 2	AttributeError: 'NoneType' object has no attribute '__setitem__'
 2	AttributeError: 'NoneType' object has no attribute '_get_first__sv9k7v_k_'
 2	AttributeError: 'NoneType' object has no attribute 'get_ha5a7z_k_'
-2	AttributeError: 'NoneType' object has no attribute 'string'
+2	AttributeError: 'Z' object has no attribute 'field'
 2	AttributeError: 'tuple' object has no attribute '__setitem__'
 2	NameError: name 'UNARY_PLUS' is not defined
 2	NameError: name 'Value_' is not defined
+2	NameError: name '_undefined' is not defined
 2	NameError: name 'kotlin_UShort' is not defined
 2	NameError: name 'test_Inner_kotlin_String_kotlin_String_' is not defined
 2	NameError: name 'translateCallArguments_0' is not defined
@@ -119,6 +124,7 @@
 2	NameError: name 'visitCall_getNameForStaticFunction_Can_t_find_name_for_declaration_FUN_OPERATOR_name_int16Array_visibility_public_modality_FINAL_____arg0_kotlin_Any___returnType_kotlin_Any_' is not defined
 2	NameError: name 'visitExpressionFunctionBodyStatements_x3__Expr__Expr__Expr_' is not defined
 2	NameError: name 'visitExpressionFunctionBodyStatements_x3__Global__Assign__Expr_' is not defined
+2	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Expr__Assign__Return_' is not defined
 2	NameError: name 'visitExpression_other__inToPyStatementTransformer_org_jetbrains_kotlin_ir_expressions_impl_IrSetFieldImpl' is not defined
 2	SyntaxError: EOL while scanning string literal
 2	SyntaxError: name 'xs' is used prior to global declaration
@@ -132,18 +138,23 @@
 2	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: jvm (9,23) in <path-truncated>
 2	java.lang.IllegalStateException: UNRESOLVED_REFERENCE: Unresolved reference: setOf (90,29) in <path-truncated>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[8]>
+2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail #2]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[Fail 2]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail 1: fail methodfail property]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail1: None]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail1: [2] object:C.foo(2);]>
-2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail: None]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail: b.x = 1]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[failed 2]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[failfail]>
 2	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test1: None]>
 2	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail: ]OK>
+1	AttributeError: 'A' object has no attribute 'f'
 1	AttributeError: 'A' object has no attribute 's'
+1	AttributeError: 'B' object has no attribute 'm'
+1	AttributeError: 'B' object has no attribute 'vo'
+1	AttributeError: 'C' object has no attribute 's'
+1	AttributeError: 'C' object has no attribute 'value'
 1	AttributeError: 'ClassB' object has no attribute 'invoke_1r174_k_'
 1	AttributeError: 'Companion_17' object has no attribute 'K'
 1	AttributeError: 'Companion_17' object has no attribute 'fromClosedRange_fcwjfj_k_'
@@ -155,12 +166,13 @@
 1	AttributeError: 'Companion_20' object has no attribute 'vo'
 1	AttributeError: 'Companion_23' object has no attribute 'vo'
 1	AttributeError: 'Derived' object has no attribute 'p'
+1	AttributeError: 'Derived1' object has no attribute 'plain'
 1	AttributeError: 'Foo' object has no attribute 'foo'
 1	AttributeError: 'Foo' object has no attribute 'p'
 1	AttributeError: 'FooImpl' object has no attribute 'x'
 1	AttributeError: 'Handler' object has no attribute 'path'
+1	AttributeError: 'Inner' object has no attribute 'fn'
 1	AttributeError: 'Inner' object has no attribute 'value'
-1	AttributeError: 'N' object has no attribute 'b'
 1	AttributeError: 'NoneType' object has no attribute '_get_first__0_k_'
 1	AttributeError: 'NoneType' object has no attribute 'add_2bq_k_'
 1	AttributeError: 'NoneType' object has no attribute 'call_0_k_'
@@ -182,10 +194,15 @@
 1	AttributeError: 'NoneType' object has no attribute 'test_0_k_'
 1	AttributeError: 'NoneType' object has no attribute 'value'
 1	AttributeError: 'NoneType' object has no attribute 'x'
+1	AttributeError: 'OK' object has no attribute 'str'
 1	AttributeError: 'Test' object has no attribute '__add__'
 1	AttributeError: 'UIntArray' object has no attribute 'intArray'
+1	AttributeError: 'X' object has no attribute 'value'
 1	AttributeError: 'Z2' object has no attribute 'p'
+1	AttributeError: '_no_name_provided__1_1' object has no attribute 'x'
+1	AttributeError: '_no_name_provided__9' object has no attribute 'b'
 1	AttributeError: '_no_name_provided__9' object has no attribute 'foo_default_nmiqce_k_'
+1	AttributeError: '_no_name_provided__9' object has no attribute 'node'
 1	AttributeError: 'bool' object has no attribute 'toString'
 1	AttributeError: 'int' object has no attribute 'hashCode'
 1	AttributeError: 'int' object has no attribute 's'
@@ -212,9 +229,10 @@
 1	NameError: name 'visitExpressionFunctionBodyStatements_x3__Assign__Expr__If_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x3__Expr__Assign__Expr_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x3__If__Expr__Return_' is not defined
+1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Assign__Assign__Expr_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Assign__Assign__Return_' is not defined
-1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Expr__Assign__Return_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Assign__Expr__Expr__Return_' is not defined
+1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Expr__Assign__Expr__Return_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Global__Assign__Assign__Expr_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x4__Global__Assign__Assign__Return_' is not defined
 1	NameError: name 'visitExpressionFunctionBodyStatements_x4__If__Assign__If__Expr_' is not defined
@@ -302,7 +320,6 @@
 1	org.junit.ComparisonFailure: expected:<OK[]> but was:<OK[OK]>
 1	org.junit.ComparisonFailure: expected:<O[K]> but was:<O[]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[<compiled_module.Nested object at [address]><compiled_module.Nested object at [address]>]>
-1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[<compiled_module.SendBuffered object at [address]>]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[<compiled_module.State object at [address]><compiled_module.State object at [address]>]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[A(string=OK)]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[FAIL 0: None]>
@@ -325,6 +342,7 @@
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail template]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail1]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail2]>
+1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail3: None]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail5]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[fail: 1]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[inner getter or setter failed]>
@@ -333,4 +351,4 @@
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[test6 fail]>
 1	org.junit.ComparisonFailure: expected:<[OK]> but was:<[wrong lambda]>
 1	org.junit.ComparisonFailure: expected:<[O]K> but was:<[fail2: K]K>
-1	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail 3: fromC_]OK>
+1	org.junit.ComparisonFailure: expected:<[]OK> but was:<[fail 3: C_]OK>

--- a/python/experiments/out_ir.py
+++ b/python/experiments/out_ir.py
@@ -431,43 +431,39 @@ def reversed(self):
 def getOrElse(self, index, defaultValue):
     return (charSequenceGet(self, index)) if ((index <= _get_lastIndex__5(self)) if (index >= 0) else (False)) else (defaultValue(index))
 
-def KotlinNothingValueException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    KotlinNothingValueException.__init__(self)
-    return _this
+def KotlinNothingValueException_init__Init_():
+    RuntimeException_init__Init_()
+    return KotlinNothingValueException()
 
 def KotlinNothingValueException_init__Create_():
-    tmp = KotlinNothingValueException_init__Init_(Object_create())
+    tmp = KotlinNothingValueException_init__Init_()
     captureStack(tmp, KotlinNothingValueException_init__Create_)
     return tmp
 
-def KotlinNothingValueException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    KotlinNothingValueException.__init__(self)
-    return _this
+def KotlinNothingValueException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return KotlinNothingValueException()
 
 def KotlinNothingValueException_init__Create__0(message):
-    tmp = KotlinNothingValueException_init__Init__0(message, Object_create())
+    tmp = KotlinNothingValueException_init__Init__0(message)
     captureStack(tmp, KotlinNothingValueException_init__Create_)
     return tmp
 
-def KotlinNothingValueException_init__Init__1(message, cause, _this):
-    RuntimeException_init__Init__1(message, cause, _this)
-    KotlinNothingValueException.__init__(self)
-    return _this
+def KotlinNothingValueException_init__Init__1(message, cause):
+    RuntimeException_init__Init__1(message, cause)
+    return KotlinNothingValueException()
 
 def KotlinNothingValueException_init__Create__1(message, cause):
-    tmp = KotlinNothingValueException_init__Init__1(message, cause, Object_create())
+    tmp = KotlinNothingValueException_init__Init__1(message, cause)
     captureStack(tmp, KotlinNothingValueException_init__Create_)
     return tmp
 
-def KotlinNothingValueException_init__Init__2(cause, _this):
-    RuntimeException_init__Init__2(cause, _this)
-    KotlinNothingValueException.__init__(self)
-    return _this
+def KotlinNothingValueException_init__Init__2(cause):
+    RuntimeException_init__Init__2(cause)
+    return KotlinNothingValueException()
 
 def KotlinNothingValueException_init__Create__2(cause):
-    tmp = KotlinNothingValueException_init__Init__2(cause, Object_create())
+    tmp = KotlinNothingValueException_init__Init__2(cause)
     captureStack(tmp, KotlinNothingValueException_init__Create_)
     return tmp
 
@@ -537,22 +533,21 @@ def Level_initEntries():
     Level_WARNING_instance = Level('WARNING', 0)
     Level_ERROR_instance = Level('ERROR', 1)
 
-def Experimental_init__Init_(level, _mask0, _marker, _this):
+def Experimental_init__Init_(level, _mask0, _marker):
     if not (_mask0 & 1 == 0):
         level = Level_ERROR_getInstance()
     
-    Experimental.__init__(self, level)
-    return _this
+    return Experimental(level)
 
 def Experimental_init__Create_(level, _mask0, _marker):
-    return Experimental_init__Init_(level, _mask0, _marker, Object_create())
+    return Experimental_init__Init_(level, _mask0, _marker)
 
 class Enum:
     pass
 
 class Level(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -685,22 +680,21 @@ def Level_initEntries_0():
     Level_WARNING_instance = Level_0('WARNING', 0)
     Level_ERROR_instance = Level_0('ERROR', 1)
 
-def RequiresOptIn_init__Init_(message, level, _mask0, _marker, _this):
+def RequiresOptIn_init__Init_(message, level, _mask0, _marker):
     if not (_mask0 & 1 == 0):
         message = ''
     
     if not (_mask0 & 2 == 0):
         level = Level_ERROR_getInstance_0()
     
-    RequiresOptIn.__init__(self, message, level)
-    return _this
+    return RequiresOptIn(message, level)
 
 def RequiresOptIn_init__Create_(message, level, _mask0, _marker):
-    return RequiresOptIn_init__Init_(message, level, _mask0, _marker, Object_create())
+    return RequiresOptIn_init__Init_(message, level, _mask0, _marker)
 
 class Level_0(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -871,7 +865,7 @@ class RandomAccess:
 
 class SubList(AbstractList, RandomAccess):
     def __init__(self, list, fromIndex, toIndex):
-        AbstractList.__init__(self)
+        AbstractList()
         self.list = list
         self.fromIndex = fromIndex
         self._size = 0
@@ -970,7 +964,7 @@ class ListIterator:
 class ListIteratorImpl(IteratorImpl, ListIterator):
     def __init__(self, _outer, index):
         self._this = _outer
-        IteratorImpl.__init__(self, _outer)
+        IteratorImpl(_outer)
         Companion_getInstance().checkPositionIndex_rvwcgf_k_(index, self._this._get_size__0_k_())
         self._set_index__majfzk_k_(index)
     
@@ -1097,7 +1091,7 @@ class List:
 class AbstractList(AbstractCollection, List):
     def __init__(self):
         Companion_getInstance()
-        AbstractCollection.__init__(self)
+        AbstractCollection()
     
     def _get_size__0_k_(self):
         pass
@@ -1504,7 +1498,7 @@ def InvocationKind_initEntries():
 
 class InvocationKind(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -2149,7 +2143,7 @@ def CoroutineSingletons_initEntries():
 
 class CoroutineSingletons(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -2220,7 +2214,7 @@ class ExperimentalTypeInference(Annotation):
         pass
     
 
-def RequireKotlin_init__Init_(version, message, level, versionKind, errorCode, _mask0, _marker, _this):
+def RequireKotlin_init__Init_(version, message, level, versionKind, errorCode, _mask0, _marker):
     if not (_mask0 & 2 == 0):
         message = ''
     
@@ -2233,11 +2227,10 @@ def RequireKotlin_init__Init_(version, message, level, versionKind, errorCode, _
     if not (_mask0 & 16 == 0):
         errorCode = -1
     
-    RequireKotlin.__init__(self, version, message, level, versionKind, errorCode)
-    return _this
+    return RequireKotlin(version, message, level, versionKind, errorCode)
 
 def RequireKotlin_init__Create_(version, message, level, versionKind, errorCode, _mask0, _marker):
-    return RequireKotlin_init__Init_(version, message, level, versionKind, errorCode, _mask0, _marker, Object_create())
+    return RequireKotlin_init__Init_(version, message, level, versionKind, errorCode, _mask0, _marker)
 
 class RequireKotlin(Annotation):
     def __init__(self, version, message, level, versionKind, errorCode):
@@ -2303,7 +2296,7 @@ def RequireKotlinVersionKind_initEntries():
 
 class RequireKotlinVersionKind(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -2601,7 +2594,7 @@ def KVariance_initEntries():
 
 class KVariance(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -2824,15 +2817,14 @@ def run(block):
 def TODO():
     raise NotImplementedError_init__Create_(None, 1, None)
 
-def NotImplementedError_init__Init_(message, _mask0, _marker, _this):
+def NotImplementedError_init__Init_(message, _mask0, _marker):
     if not (_mask0 & 1 == 0):
         message = 'An operation is not implemented.'
     
-    NotImplementedError.__init__(self, message)
-    return _this
+    return NotImplementedError(message)
 
 def NotImplementedError_init__Create_(message, _mask0, _marker):
-    tmp = NotImplementedError_init__Init_(message, _mask0, _marker, Object_create())
+    tmp = NotImplementedError_init__Init_(message, _mask0, _marker)
     captureStack(tmp, NotImplementedError_init__Create_)
     return tmp
 
@@ -2841,7 +2833,7 @@ class Error_0:
 
 class NotImplementedError(Error_0):
     def __init__(self, message):
-        Error_init__Init__0(message, self)
+        Error_init__Init__0(message)
         captureStack(self, _init_)
     
     def _get_message__0_k_(self):
@@ -3235,7 +3227,7 @@ class UByteIterator:
 
 class Iterator(UByteIterator):
     def __init__(self, array):
-        UByteIterator.__init__(self)
+        UByteIterator()
         self.array = array
         self.index = 0
     
@@ -3697,7 +3689,7 @@ class UIntIterator:
 
 class Iterator_0(UIntIterator):
     def __init__(self, array):
-        UIntIterator.__init__(self)
+        UIntIterator()
         self.array = array
         self.index = 0
     
@@ -3874,7 +3866,7 @@ class ClosedRange:
 class UIntRange(UIntProgression, ClosedRange):
     def __init__(self, start, endInclusive):
         Companion_getInstance_5()
-        UIntProgression.__init__(self, start, endInclusive, 1)
+        UIntProgression(start, endInclusive, 1)
     
     def _get_start__sv9k7v_k_(self):
         return self._get_first__sv9k7v_k_()
@@ -4049,7 +4041,7 @@ def _get_next_(_this):
 
 class UIntProgressionIterator(UIntIterator):
     def __init__(self, first, last, step):
-        UIntIterator.__init__(self)
+        UIntIterator()
         self.finalElement = last
         tmp = self
         if step > 0:
@@ -4522,7 +4514,7 @@ def ULongArray__iterator_impl(this):
 
 class Iterator_1(ULongIterator):
     def __init__(self, array):
-        ULongIterator.__init__(self)
+        ULongIterator()
         self.array = array
         self.index = 0
     
@@ -4696,7 +4688,7 @@ class ULongProgression:
 class ULongRange(ULongProgression, ClosedRange):
     def __init__(self, start, endInclusive):
         Companion_getInstance_8()
-        ULongProgression.__init__(self, start, endInclusive, 1)
+        ULongProgression(start, endInclusive, 1)
     
     def _get_start__sha8jq_k_(self):
         return self._get_first__sha8jq_k_()
@@ -4881,7 +4873,7 @@ def _get_next__0(_this):
 
 class ULongProgressionIterator(ULongIterator):
     def __init__(self, first, last, step):
-        ULongIterator.__init__(self)
+        ULongIterator()
         self.finalElement = last
         tmp = self
         if step.compareTo_wiekkq_k_(0) > 0:
@@ -5329,7 +5321,7 @@ def UShortArray__iterator_impl(this):
 
 class Iterator_2(UShortIterator):
     def __init__(self, array):
-        UShortIterator.__init__(self)
+        UShortIterator()
         self.array = array
         self.index = 0
     
@@ -5905,7 +5897,7 @@ def DeprecationLevel_initEntries():
 
 class DeprecationLevel(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -5957,18 +5949,17 @@ class ParameterName(Annotation):
         pass
     
 
-def Deprecated_init__Init_(message, replaceWith, level, _mask0, _marker, _this):
+def Deprecated_init__Init_(message, replaceWith, level, _mask0, _marker):
     if not (_mask0 & 2 == 0):
         replaceWith = ReplaceWith('', *())
     
     if not (_mask0 & 4 == 0):
         level = DeprecationLevel_WARNING_getInstance()
     
-    Deprecated.__init__(self, message, replaceWith, level)
-    return _this
+    return Deprecated(message, replaceWith, level)
 
 def Deprecated_init__Create_(message, replaceWith, level, _mask0, _marker):
-    return Deprecated_init__Init_(message, replaceWith, level, _mask0, _marker, Object_create())
+    return Deprecated_init__Init_(message, replaceWith, level, _mask0, _marker)
 
 class Deprecated(Annotation):
     def __init__(self, message, replaceWith, level):
@@ -6016,7 +6007,7 @@ class ReplaceWith(Annotation):
         pass
     
 
-def DeprecatedSinceKotlin_init__Init_(warningSince, errorSince, hiddenSince, _mask0, _marker, _this):
+def DeprecatedSinceKotlin_init__Init_(warningSince, errorSince, hiddenSince, _mask0, _marker):
     if not (_mask0 & 1 == 0):
         warningSince = ''
     
@@ -6026,11 +6017,10 @@ def DeprecatedSinceKotlin_init__Init_(warningSince, errorSince, hiddenSince, _ma
     if not (_mask0 & 4 == 0):
         hiddenSince = ''
     
-    DeprecatedSinceKotlin.__init__(self, warningSince, errorSince, hiddenSince)
-    return _this
+    return DeprecatedSinceKotlin(warningSince, errorSince, hiddenSince)
 
 def DeprecatedSinceKotlin_init__Create_(warningSince, errorSince, hiddenSince, _mask0, _marker):
-    return DeprecatedSinceKotlin_init__Init_(warningSince, errorSince, hiddenSince, _mask0, _marker, Object_create())
+    return DeprecatedSinceKotlin_init__Init_(warningSince, errorSince, hiddenSince, _mask0, _marker)
 
 class DeprecatedSinceKotlin(Annotation):
     def __init__(self, warningSince, errorSince, hiddenSince):
@@ -6298,7 +6288,7 @@ def _get_next__1(_this):
 
 class IntProgressionIterator(IntIterator):
     def __init__(self, first, last, step):
-        IntIterator.__init__(self)
+        IntIterator()
         self.step = step
         self.finalElement = last
         self.hasNext = (first <= last) if (self.step > 0) else (first >= last)
@@ -6353,7 +6343,7 @@ def _get_next__2(_this):
 
 class LongProgressionIterator(LongIterator):
     def __init__(self, first, last, step):
-        LongIterator.__init__(self)
+        LongIterator()
         self.step = step
         self.finalElement = last
         self.hasNext = (first.compareTo_wiekkq_k_(last) <= 0) if (self.step.compareTo_wiekkq_k_(0) > 0) else (first.compareTo_wiekkq_k_(last) >= 0)
@@ -6408,7 +6398,7 @@ def _get_next__3(_this):
 
 class CharProgressionIterator(CharIterator):
     def __init__(self, first, last, step):
-        CharIterator.__init__(self)
+        CharIterator()
         self.step = step
         tmp = self
         tmp.finalElement = last.toInt_0_k_()
@@ -6723,7 +6713,7 @@ def Companion_getInstance_14():
 class IntRange(IntProgression, ClosedRange):
     def __init__(self, start, endInclusive):
         Companion_getInstance_14()
-        IntProgression.__init__(self, start, endInclusive, 1)
+        IntProgression(start, endInclusive, 1)
     
     def _get_start__0_k_(self):
         return self._get_first__0_k_()
@@ -6796,7 +6786,7 @@ def Companion_getInstance_15():
 class LongRange(LongProgression, ClosedRange):
     def __init__(self, start, endInclusive):
         Companion_getInstance_15()
-        LongProgression.__init__(self, start, endInclusive, 1)
+        LongProgression(start, endInclusive, 1)
     
     def _get_start__0_k_(self):
         return self._get_first__0_k_()
@@ -6869,7 +6859,7 @@ def Companion_getInstance_16():
 class CharRange(CharProgression, ClosedRange):
     def __init__(self, start, endInclusive):
         Companion_getInstance_16()
-        CharProgression.__init__(self, start, endInclusive, 1)
+        CharProgression(start, endInclusive, 1)
     
     def _get_start__0_k_(self):
         return self._get_first__0_k_()
@@ -7039,7 +7029,7 @@ def AnnotationTarget_initEntries():
 
 class AnnotationTarget(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -7074,15 +7064,14 @@ class MustBeDocumented(Annotation):
         pass
     
 
-def Retention_init__Init_(value, _mask0, _marker, _this):
+def Retention_init__Init_(value, _mask0, _marker):
     if not (_mask0 & 1 == 0):
         value = AnnotationRetention_RUNTIME_getInstance()
     
-    Retention.__init__(self, value)
-    return _this
+    return Retention(value)
 
 def Retention_init__Create_(value, _mask0, _marker):
-    return Retention_init__Init_(value, _mask0, _marker, Object_create())
+    return Retention_init__Init_(value, _mask0, _marker)
 
 class Retention(Annotation):
     def __init__(self, value):
@@ -7132,7 +7121,7 @@ def AnnotationRetention_initEntries():
 
 class AnnotationRetention(Enum):
     def __init__(self, name, ordinal):
-        Enum.__init__(self, name, ordinal)
+        Enum(name, ordinal)
     
     def _get_name__0_k_(self):
         pass
@@ -7643,7 +7632,7 @@ class MutableCollection:
 
 class AbstractMutableCollection(AbstractCollection, MutableCollection):
     def __init__(self):
-        AbstractCollection.__init__(self)
+        AbstractCollection()
     
     def add_2bq_k_(self, element):
         pass
@@ -7793,7 +7782,7 @@ class IteratorImpl_0(MutableIterator):
 class ListIteratorImpl_0(IteratorImpl_0, MutableListIterator):
     def __init__(self, _outer, index):
         self._this = _outer
-        IteratorImpl_0.__init__(self, _outer)
+        IteratorImpl_0(_outer)
         Companion_getInstance().checkPositionIndex_rvwcgf_k_(index, self._this._get_size__0_k_())
         self._set_index__majfzk_k_(index)
     
@@ -7874,7 +7863,7 @@ class AbstractMutableList:
 
 class SubList_0(AbstractMutableList, RandomAccess):
     def __init__(self, list, fromIndex, toIndex):
-        AbstractMutableList.__init__(self)
+        AbstractMutableList()
         self.list = list
         self.fromIndex = fromIndex
         self._size = 0
@@ -7993,7 +7982,7 @@ class MutableList:
 
 class AbstractMutableList(AbstractMutableCollection, MutableList):
     def __init__(self):
-        AbstractMutableCollection.__init__(self)
+        AbstractMutableCollection()
         self.modCount = 0
     
     def _set_modCount__majfzk_k_(self, _set___):
@@ -8165,36 +8154,32 @@ def _set_isReadOnly_(_this, _set___):
 def _get_isReadOnly_(_this):
     return _this.isReadOnly
 
-def ArrayList_init__Init_(_this):
-    ArrayList.__init__(self, kotlin_Array_kotlin_Any__(js('[]')))
-    return _this
+def ArrayList_init__Init_():
+    return ArrayList(kotlin_Array_kotlin_Any__(js('[]')))
 
 def ArrayList_init__Create_():
-    return ArrayList_init__Init_(Object_create())
+    return ArrayList_init__Init_()
 
-def ArrayList_init__Init__0(initialCapacity, _this):
-    ArrayList.__init__(self, kotlin_Array_kotlin_Any__(js('[]')))
-    return _this
+def ArrayList_init__Init__0(initialCapacity):
+    return ArrayList(kotlin_Array_kotlin_Any__(js('[]')))
 
 def ArrayList_init__Create__0(initialCapacity):
-    return ArrayList_init__Init__0(initialCapacity, Object_create())
+    return ArrayList_init__Init__0(initialCapacity)
 
-def ArrayList_init__Init__1(initialCapacity, _mask0, _marker, _this):
+def ArrayList_init__Init__1(initialCapacity, _mask0, _marker):
     if not (_mask0 & 1 == 0):
         initialCapacity = 0
     
-    ArrayList_init__Init__0(initialCapacity, _this)
-    return _this
+    return ArrayList_init__Init__0(initialCapacity)
 
 def ArrayList_init__Create__1(initialCapacity, _mask0, _marker):
-    return ArrayList_init__Init__1(initialCapacity, _mask0, _marker, Object_create())
+    return ArrayList_init__Init__1(initialCapacity, _mask0, _marker)
 
-def ArrayList_init__Init__2(elements, _this):
-    ArrayList.__init__(self, copyToArray_0(elements))
-    return _this
+def ArrayList_init__Init__2(elements):
+    return ArrayList(copyToArray_0(elements))
 
 def ArrayList_init__Create__2(elements):
-    return ArrayList_init__Init__2(elements, Object_create())
+    return ArrayList_init__Init__2(elements)
 
 def rangeCheck(_this, index):
     Companion_getInstance().checkElementIndex_rvwcgf_k_(index, _this._get_size__0_k_())
@@ -8206,7 +8191,7 @@ def insertionRangeCheck(_this, index):
 
 class ArrayList(AbstractMutableList, MutableList, RandomAccess):
     def __init__(self, array):
-        AbstractMutableList.__init__(self)
+        AbstractMutableList()
         self.array = array
         self.isReadOnly = False
     
@@ -8498,7 +8483,7 @@ class BaseOutput(Any):
 
 class NodeJsOutput_0(BaseOutput):
     def __init__(self, outputStream):
-        BaseOutput.__init__(self)
+        BaseOutput()
         self.outputStream = outputStream
     
     def _get_outputStream__0_k_(self):
@@ -8532,7 +8517,7 @@ class BufferedOutput_0:
 
 class BufferedOutputToConsoleLog_0(BufferedOutput_0):
     def __init__(self):
-        BufferedOutput_0.__init__(self)
+        BufferedOutput_0()
     
     def print_qi8yb4_k_(self, message):
         s = kotlin_String(INVOKE(js('String'), message))
@@ -8582,7 +8567,7 @@ def String_0(value):
 
 class BufferedOutput_0(BaseOutput):
     def __init__(self):
-        BaseOutput.__init__(self)
+        BaseOutput()
         self.buffer = ''
     
     def _set_buffer__a4enbm_k_(self, _set___):
@@ -8791,7 +8776,7 @@ def _get_isInstanceFunction_(_this):
 
 class PrimitiveKClassImpl(KClassImpl):
     def __init__(self, jClass, givenSimpleName, isInstanceFunction):
-        KClassImpl.__init__(self, jClass)
+        KClassImpl(jClass)
         self.givenSimpleName = givenSimpleName
         self.isInstanceFunction = isInstanceFunction
     
@@ -8824,7 +8809,7 @@ class NothingKClassImpl(KClassImpl):
     def __init__(self):
         global NothingKClassImpl_instance
         NothingKClassImpl_instance = self
-        KClassImpl.__init__(self, kotlin_js_JsClass_kotlin_Nothing_(js('Object')))
+        KClassImpl(kotlin_js_JsClass_kotlin_Nothing_(js('Object')))
         self.simpleName = 'Nothing'
     
     def _get_simpleName__0_k_(self):
@@ -8881,7 +8866,7 @@ class ErrorKClass(KClass):
 
 class SimpleKClassImpl(KClassImpl):
     def __init__(self, jClass):
-        KClassImpl.__init__(self, jClass)
+        KClassImpl(jClass)
         tmp = self
         tmp0_safe_receiver = _metadata_(jClass)
         tmp0_unsafeCast_0 = (None) if (tmp0_safe_receiver == None) else (simpleName(tmp0_safe_receiver))
@@ -9623,26 +9608,23 @@ class Appendable(Any):
         pass
     
 
-def StringBuilder_init__Init_(capacity, _this):
-    StringBuilder_init__Init__1(_this)
-    return _this
+def StringBuilder_init__Init_(capacity):
+    return StringBuilder_init__Init__1()
 
 def StringBuilder_init__Create_(capacity):
-    return StringBuilder_init__Init_(capacity, Object_create())
+    return StringBuilder_init__Init_(capacity)
 
-def StringBuilder_init__Init__0(content, _this):
-    StringBuilder.__init__(self, toString_0(content))
-    return _this
+def StringBuilder_init__Init__0(content):
+    return StringBuilder(toString_0(content))
 
 def StringBuilder_init__Create__0(content):
-    return StringBuilder_init__Init__0(content, Object_create())
+    return StringBuilder_init__Init__0(content)
 
-def StringBuilder_init__Init__1(_this):
-    StringBuilder.__init__(self, '')
-    return _this
+def StringBuilder_init__Init__1():
+    return StringBuilder('')
 
 def StringBuilder_init__Create__1():
-    return StringBuilder_init__Init__1(Object_create())
+    return StringBuilder_init__Init__1()
 
 def _set_string_(_this, _set___):
     _this.string = _set___
@@ -10990,7 +10972,7 @@ class _no_name_provided__0(Iterator_3):
 class _no_name_provided__2(BooleanIterator):
     def __init__(self, _array):
         self._array = _array
-        BooleanIterator.__init__(self)
+        BooleanIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11029,7 +11011,7 @@ class _no_name_provided__2(BooleanIterator):
 class _no_name_provided__3(CharIterator):
     def __init__(self, _array):
         self._array = _array
-        CharIterator.__init__(self)
+        CharIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11068,7 +11050,7 @@ class _no_name_provided__3(CharIterator):
 class _no_name_provided__4(ByteIterator):
     def __init__(self, _array):
         self._array = _array
-        ByteIterator.__init__(self)
+        ByteIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11107,7 +11089,7 @@ class _no_name_provided__4(ByteIterator):
 class _no_name_provided__5(ShortIterator):
     def __init__(self, _array):
         self._array = _array
-        ShortIterator.__init__(self)
+        ShortIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11146,7 +11128,7 @@ class _no_name_provided__5(ShortIterator):
 class _no_name_provided__6(IntIterator):
     def __init__(self, _array):
         self._array = _array
-        IntIterator.__init__(self)
+        IntIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11185,7 +11167,7 @@ class _no_name_provided__6(IntIterator):
 class _no_name_provided__7(FloatIterator):
     def __init__(self, _array):
         self._array = _array
-        FloatIterator.__init__(self)
+        FloatIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11224,7 +11206,7 @@ class _no_name_provided__7(FloatIterator):
 class _no_name_provided__8(LongIterator):
     def __init__(self, _array):
         self._array = _array
-        LongIterator.__init__(self)
+        LongIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11263,7 +11245,7 @@ class _no_name_provided__8(LongIterator):
 class _no_name_provided__9(DoubleIterator):
     def __init__(self, _array):
         self._array = _array
-        DoubleIterator.__init__(self)
+        DoubleIterator()
         self.index = 0
     
     def _set_index__majfzk_k_(self, _set___):
@@ -11747,7 +11729,7 @@ def Companion_getInstance_19():
 class Long(Number_0, Comparable):
     def __init__(self, low, high):
         Companion_getInstance_19()
-        Number_0.__init__(self)
+        Number_0()
         self.low = low
         self.high = high
     
@@ -12760,43 +12742,39 @@ def CompletedContinuation_getInstance():
     
     return CompletedContinuation_instance
 
-def Exception_init__Init_(_this):
-    extendThrowable(_this, _undefined(), _undefined())
-    Exception.__init__(self)
-    return _this
+def Exception_init__Init_():
+    extendThrowable(self, _undefined(), _undefined())
+    return Exception()
 
 def Exception_init__Create_():
-    tmp = Exception_init__Init_(Object_create())
+    tmp = Exception_init__Init_()
     captureStack(tmp, Exception_init__Create_)
     return tmp
 
-def Exception_init__Init__0(message, _this):
-    extendThrowable(_this, message, _undefined())
-    Exception.__init__(self)
-    return _this
+def Exception_init__Init__0(message):
+    extendThrowable(self, message, _undefined())
+    return Exception()
 
 def Exception_init__Create__0(message):
-    tmp = Exception_init__Init__0(message, Object_create())
+    tmp = Exception_init__Init__0(message)
     captureStack(tmp, Exception_init__Create_)
     return tmp
 
-def Exception_init__Init__1(message, cause, _this):
-    extendThrowable(_this, message, cause)
-    Exception.__init__(self)
-    return _this
+def Exception_init__Init__1(message, cause):
+    extendThrowable(self, message, cause)
+    return Exception()
 
 def Exception_init__Create__1(message, cause):
-    tmp = Exception_init__Init__1(message, cause, Object_create())
+    tmp = Exception_init__Init__1(message, cause)
     captureStack(tmp, Exception_init__Create_)
     return tmp
 
-def Exception_init__Init__2(cause, _this):
-    extendThrowable(_this, _undefined(), cause)
-    Exception.__init__(self)
-    return _this
+def Exception_init__Init__2(cause):
+    extendThrowable(self, _undefined(), cause)
+    return Exception()
 
 def Exception_init__Create__2(cause):
-    tmp = Exception_init__Init__2(cause, Object_create())
+    tmp = Exception_init__Init__2(cause)
     captureStack(tmp, Exception_init__Create_)
     return tmp
 
@@ -12823,43 +12801,39 @@ class Exception(Error):
         captureStack(self, _init_)
     
 
-def Error_init__Init_(_this):
-    extendThrowable(_this, _undefined(), _undefined())
-    Error_0.__init__(self)
-    return _this
+def Error_init__Init_():
+    extendThrowable(self, _undefined(), _undefined())
+    return Error_0()
 
 def Error_init__Create_():
-    tmp = Error_init__Init_(Object_create())
+    tmp = Error_init__Init_()
     captureStack(tmp, Error_init__Create_)
     return tmp
 
-def Error_init__Init__0(message, _this):
-    extendThrowable(_this, message, _undefined())
-    Error_0.__init__(self)
-    return _this
+def Error_init__Init__0(message):
+    extendThrowable(self, message, _undefined())
+    return Error_0()
 
 def Error_init__Create__0(message):
-    tmp = Error_init__Init__0(message, Object_create())
+    tmp = Error_init__Init__0(message)
     captureStack(tmp, Error_init__Create_)
     return tmp
 
-def Error_init__Init__1(message, cause, _this):
-    extendThrowable(_this, message, cause)
-    Error_0.__init__(self)
-    return _this
+def Error_init__Init__1(message, cause):
+    extendThrowable(self, message, cause)
+    return Error_0()
 
 def Error_init__Create__1(message, cause):
-    tmp = Error_init__Init__1(message, cause, Object_create())
+    tmp = Error_init__Init__1(message, cause)
     captureStack(tmp, Error_init__Create_)
     return tmp
 
-def Error_init__Init__2(cause, _this):
-    extendThrowable(_this, _undefined(), cause)
-    Error_0.__init__(self)
-    return _this
+def Error_init__Init__2(cause):
+    extendThrowable(self, _undefined(), cause)
+    return Error_0()
 
 def Error_init__Create__2(cause):
-    tmp = Error_init__Init__2(cause, Object_create())
+    tmp = Error_init__Init__2(cause)
     captureStack(tmp, Error_init__Create_)
     return tmp
 
@@ -12883,43 +12857,39 @@ class Error_0(Error):
         captureStack(self, _init_)
     
 
-def IllegalArgumentException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    IllegalArgumentException.__init__(self)
-    return _this
+def IllegalArgumentException_init__Init_():
+    RuntimeException_init__Init_()
+    return IllegalArgumentException()
 
 def IllegalArgumentException_init__Create_():
-    tmp = IllegalArgumentException_init__Init_(Object_create())
+    tmp = IllegalArgumentException_init__Init_()
     captureStack(tmp, IllegalArgumentException_init__Create_)
     return tmp
 
-def IllegalArgumentException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    IllegalArgumentException.__init__(self)
-    return _this
+def IllegalArgumentException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return IllegalArgumentException()
 
 def IllegalArgumentException_init__Create__0(message):
-    tmp = IllegalArgumentException_init__Init__0(message, Object_create())
+    tmp = IllegalArgumentException_init__Init__0(message)
     captureStack(tmp, IllegalArgumentException_init__Create_)
     return tmp
 
-def IllegalArgumentException_init__Init__1(message, cause, _this):
-    RuntimeException_init__Init__1(message, cause, _this)
-    IllegalArgumentException.__init__(self)
-    return _this
+def IllegalArgumentException_init__Init__1(message, cause):
+    RuntimeException_init__Init__1(message, cause)
+    return IllegalArgumentException()
 
 def IllegalArgumentException_init__Create__1(message, cause):
-    tmp = IllegalArgumentException_init__Init__1(message, cause, Object_create())
+    tmp = IllegalArgumentException_init__Init__1(message, cause)
     captureStack(tmp, IllegalArgumentException_init__Create_)
     return tmp
 
-def IllegalArgumentException_init__Init__2(cause, _this):
-    RuntimeException_init__Init__2(cause, _this)
-    IllegalArgumentException.__init__(self)
-    return _this
+def IllegalArgumentException_init__Init__2(cause):
+    RuntimeException_init__Init__2(cause)
+    return IllegalArgumentException()
 
 def IllegalArgumentException_init__Create__2(cause):
-    tmp = IllegalArgumentException_init__Init__2(cause, Object_create())
+    tmp = IllegalArgumentException_init__Init__2(cause)
     captureStack(tmp, IllegalArgumentException_init__Create_)
     return tmp
 
@@ -12943,43 +12913,39 @@ class IllegalArgumentException(RuntimeException):
         captureStack(self, _init_)
     
 
-def RuntimeException_init__Init_(_this):
-    Exception_init__Init_(_this)
-    RuntimeException.__init__(self)
-    return _this
+def RuntimeException_init__Init_():
+    Exception_init__Init_()
+    return RuntimeException()
 
 def RuntimeException_init__Create_():
-    tmp = RuntimeException_init__Init_(Object_create())
+    tmp = RuntimeException_init__Init_()
     captureStack(tmp, RuntimeException_init__Create_)
     return tmp
 
-def RuntimeException_init__Init__0(message, _this):
-    Exception_init__Init__0(message, _this)
-    RuntimeException.__init__(self)
-    return _this
+def RuntimeException_init__Init__0(message):
+    Exception_init__Init__0(message)
+    return RuntimeException()
 
 def RuntimeException_init__Create__0(message):
-    tmp = RuntimeException_init__Init__0(message, Object_create())
+    tmp = RuntimeException_init__Init__0(message)
     captureStack(tmp, RuntimeException_init__Create_)
     return tmp
 
-def RuntimeException_init__Init__1(message, cause, _this):
-    Exception_init__Init__1(message, cause, _this)
-    RuntimeException.__init__(self)
-    return _this
+def RuntimeException_init__Init__1(message, cause):
+    Exception_init__Init__1(message, cause)
+    return RuntimeException()
 
 def RuntimeException_init__Create__1(message, cause):
-    tmp = RuntimeException_init__Init__1(message, cause, Object_create())
+    tmp = RuntimeException_init__Init__1(message, cause)
     captureStack(tmp, RuntimeException_init__Create_)
     return tmp
 
-def RuntimeException_init__Init__2(cause, _this):
-    Exception_init__Init__2(cause, _this)
-    RuntimeException.__init__(self)
-    return _this
+def RuntimeException_init__Init__2(cause):
+    Exception_init__Init__2(cause)
+    return RuntimeException()
 
 def RuntimeException_init__Create__2(cause):
-    tmp = RuntimeException_init__Init__2(cause, Object_create())
+    tmp = RuntimeException_init__Init__2(cause)
     captureStack(tmp, RuntimeException_init__Create_)
     return tmp
 
@@ -13003,23 +12969,21 @@ class RuntimeException(Exception):
         captureStack(self, _init_)
     
 
-def NoSuchElementException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    NoSuchElementException.__init__(self)
-    return _this
+def NoSuchElementException_init__Init_():
+    RuntimeException_init__Init_()
+    return NoSuchElementException()
 
 def NoSuchElementException_init__Create_():
-    tmp = NoSuchElementException_init__Init_(Object_create())
+    tmp = NoSuchElementException_init__Init_()
     captureStack(tmp, NoSuchElementException_init__Create_)
     return tmp
 
-def NoSuchElementException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    NoSuchElementException.__init__(self)
-    return _this
+def NoSuchElementException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return NoSuchElementException()
 
 def NoSuchElementException_init__Create__0(message):
-    tmp = NoSuchElementException_init__Init__0(message, Object_create())
+    tmp = NoSuchElementException_init__Init__0(message)
     captureStack(tmp, NoSuchElementException_init__Create_)
     return tmp
 
@@ -13043,43 +13007,39 @@ class NoSuchElementException(RuntimeException):
         captureStack(self, _init_)
     
 
-def IllegalStateException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    IllegalStateException.__init__(self)
-    return _this
+def IllegalStateException_init__Init_():
+    RuntimeException_init__Init_()
+    return IllegalStateException()
 
 def IllegalStateException_init__Create_():
-    tmp = IllegalStateException_init__Init_(Object_create())
+    tmp = IllegalStateException_init__Init_()
     captureStack(tmp, IllegalStateException_init__Create_)
     return tmp
 
-def IllegalStateException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    IllegalStateException.__init__(self)
-    return _this
+def IllegalStateException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return IllegalStateException()
 
 def IllegalStateException_init__Create__0(message):
-    tmp = IllegalStateException_init__Init__0(message, Object_create())
+    tmp = IllegalStateException_init__Init__0(message)
     captureStack(tmp, IllegalStateException_init__Create_)
     return tmp
 
-def IllegalStateException_init__Init__1(message, cause, _this):
-    RuntimeException_init__Init__1(message, cause, _this)
-    IllegalStateException.__init__(self)
-    return _this
+def IllegalStateException_init__Init__1(message, cause):
+    RuntimeException_init__Init__1(message, cause)
+    return IllegalStateException()
 
 def IllegalStateException_init__Create__1(message, cause):
-    tmp = IllegalStateException_init__Init__1(message, cause, Object_create())
+    tmp = IllegalStateException_init__Init__1(message, cause)
     captureStack(tmp, IllegalStateException_init__Create_)
     return tmp
 
-def IllegalStateException_init__Init__2(cause, _this):
-    RuntimeException_init__Init__2(cause, _this)
-    IllegalStateException.__init__(self)
-    return _this
+def IllegalStateException_init__Init__2(cause):
+    RuntimeException_init__Init__2(cause)
+    return IllegalStateException()
 
 def IllegalStateException_init__Create__2(cause):
-    tmp = IllegalStateException_init__Init__2(cause, Object_create())
+    tmp = IllegalStateException_init__Init__2(cause)
     captureStack(tmp, IllegalStateException_init__Create_)
     return tmp
 
@@ -13103,23 +13063,21 @@ class IllegalStateException(RuntimeException):
         captureStack(self, _init_)
     
 
-def IndexOutOfBoundsException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    IndexOutOfBoundsException.__init__(self)
-    return _this
+def IndexOutOfBoundsException_init__Init_():
+    RuntimeException_init__Init_()
+    return IndexOutOfBoundsException()
 
 def IndexOutOfBoundsException_init__Create_():
-    tmp = IndexOutOfBoundsException_init__Init_(Object_create())
+    tmp = IndexOutOfBoundsException_init__Init_()
     captureStack(tmp, IndexOutOfBoundsException_init__Create_)
     return tmp
 
-def IndexOutOfBoundsException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    IndexOutOfBoundsException.__init__(self)
-    return _this
+def IndexOutOfBoundsException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return IndexOutOfBoundsException()
 
 def IndexOutOfBoundsException_init__Create__0(message):
-    tmp = IndexOutOfBoundsException_init__Init__0(message, Object_create())
+    tmp = IndexOutOfBoundsException_init__Init__0(message)
     captureStack(tmp, IndexOutOfBoundsException_init__Create_)
     return tmp
 
@@ -13143,43 +13101,39 @@ class IndexOutOfBoundsException(RuntimeException):
         captureStack(self, _init_)
     
 
-def UnsupportedOperationException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    UnsupportedOperationException.__init__(self)
-    return _this
+def UnsupportedOperationException_init__Init_():
+    RuntimeException_init__Init_()
+    return UnsupportedOperationException()
 
 def UnsupportedOperationException_init__Create_():
-    tmp = UnsupportedOperationException_init__Init_(Object_create())
+    tmp = UnsupportedOperationException_init__Init_()
     captureStack(tmp, UnsupportedOperationException_init__Create_)
     return tmp
 
-def UnsupportedOperationException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    UnsupportedOperationException.__init__(self)
-    return _this
+def UnsupportedOperationException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return UnsupportedOperationException()
 
 def UnsupportedOperationException_init__Create__0(message):
-    tmp = UnsupportedOperationException_init__Init__0(message, Object_create())
+    tmp = UnsupportedOperationException_init__Init__0(message)
     captureStack(tmp, UnsupportedOperationException_init__Create_)
     return tmp
 
-def UnsupportedOperationException_init__Init__1(message, cause, _this):
-    RuntimeException_init__Init__1(message, cause, _this)
-    UnsupportedOperationException.__init__(self)
-    return _this
+def UnsupportedOperationException_init__Init__1(message, cause):
+    RuntimeException_init__Init__1(message, cause)
+    return UnsupportedOperationException()
 
 def UnsupportedOperationException_init__Create__1(message, cause):
-    tmp = UnsupportedOperationException_init__Init__1(message, cause, Object_create())
+    tmp = UnsupportedOperationException_init__Init__1(message, cause)
     captureStack(tmp, UnsupportedOperationException_init__Create_)
     return tmp
 
-def UnsupportedOperationException_init__Init__2(cause, _this):
-    RuntimeException_init__Init__2(cause, _this)
-    UnsupportedOperationException.__init__(self)
-    return _this
+def UnsupportedOperationException_init__Init__2(cause):
+    RuntimeException_init__Init__2(cause)
+    return UnsupportedOperationException()
 
 def UnsupportedOperationException_init__Create__2(cause):
-    tmp = UnsupportedOperationException_init__Init__2(cause, Object_create())
+    tmp = UnsupportedOperationException_init__Init__2(cause)
     captureStack(tmp, UnsupportedOperationException_init__Create_)
     return tmp
 
@@ -13203,23 +13157,21 @@ class UnsupportedOperationException(RuntimeException):
         captureStack(self, _init_)
     
 
-def NullPointerException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    NullPointerException.__init__(self)
-    return _this
+def NullPointerException_init__Init_():
+    RuntimeException_init__Init_()
+    return NullPointerException()
 
 def NullPointerException_init__Create_():
-    tmp = NullPointerException_init__Init_(Object_create())
+    tmp = NullPointerException_init__Init_()
     captureStack(tmp, NullPointerException_init__Create_)
     return tmp
 
-def NullPointerException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    NullPointerException.__init__(self)
-    return _this
+def NullPointerException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return NullPointerException()
 
 def NullPointerException_init__Create__0(message):
-    tmp = NullPointerException_init__Init__0(message, Object_create())
+    tmp = NullPointerException_init__Init__0(message)
     captureStack(tmp, NullPointerException_init__Create_)
     return tmp
 
@@ -13243,43 +13195,39 @@ class NullPointerException(RuntimeException):
         captureStack(self, _init_)
     
 
-def NoWhenBranchMatchedException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    NoWhenBranchMatchedException.__init__(self)
-    return _this
+def NoWhenBranchMatchedException_init__Init_():
+    RuntimeException_init__Init_()
+    return NoWhenBranchMatchedException()
 
 def NoWhenBranchMatchedException_init__Create_():
-    tmp = NoWhenBranchMatchedException_init__Init_(Object_create())
+    tmp = NoWhenBranchMatchedException_init__Init_()
     captureStack(tmp, NoWhenBranchMatchedException_init__Create_)
     return tmp
 
-def NoWhenBranchMatchedException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    NoWhenBranchMatchedException.__init__(self)
-    return _this
+def NoWhenBranchMatchedException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return NoWhenBranchMatchedException()
 
 def NoWhenBranchMatchedException_init__Create__0(message):
-    tmp = NoWhenBranchMatchedException_init__Init__0(message, Object_create())
+    tmp = NoWhenBranchMatchedException_init__Init__0(message)
     captureStack(tmp, NoWhenBranchMatchedException_init__Create_)
     return tmp
 
-def NoWhenBranchMatchedException_init__Init__1(message, cause, _this):
-    RuntimeException_init__Init__1(message, cause, _this)
-    NoWhenBranchMatchedException.__init__(self)
-    return _this
+def NoWhenBranchMatchedException_init__Init__1(message, cause):
+    RuntimeException_init__Init__1(message, cause)
+    return NoWhenBranchMatchedException()
 
 def NoWhenBranchMatchedException_init__Create__1(message, cause):
-    tmp = NoWhenBranchMatchedException_init__Init__1(message, cause, Object_create())
+    tmp = NoWhenBranchMatchedException_init__Init__1(message, cause)
     captureStack(tmp, NoWhenBranchMatchedException_init__Create_)
     return tmp
 
-def NoWhenBranchMatchedException_init__Init__2(cause, _this):
-    RuntimeException_init__Init__2(cause, _this)
-    NoWhenBranchMatchedException.__init__(self)
-    return _this
+def NoWhenBranchMatchedException_init__Init__2(cause):
+    RuntimeException_init__Init__2(cause)
+    return NoWhenBranchMatchedException()
 
 def NoWhenBranchMatchedException_init__Create__2(cause):
-    tmp = NoWhenBranchMatchedException_init__Init__2(cause, Object_create())
+    tmp = NoWhenBranchMatchedException_init__Init__2(cause)
     captureStack(tmp, NoWhenBranchMatchedException_init__Create_)
     return tmp
 
@@ -13303,23 +13251,21 @@ class NoWhenBranchMatchedException(RuntimeException):
         captureStack(self, _init_)
     
 
-def ClassCastException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    ClassCastException.__init__(self)
-    return _this
+def ClassCastException_init__Init_():
+    RuntimeException_init__Init_()
+    return ClassCastException()
 
 def ClassCastException_init__Create_():
-    tmp = ClassCastException_init__Init_(Object_create())
+    tmp = ClassCastException_init__Init_()
     captureStack(tmp, ClassCastException_init__Create_)
     return tmp
 
-def ClassCastException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    ClassCastException.__init__(self)
-    return _this
+def ClassCastException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return ClassCastException()
 
 def ClassCastException_init__Create__0(message):
-    tmp = ClassCastException_init__Init__0(message, Object_create())
+    tmp = ClassCastException_init__Init__0(message)
     captureStack(tmp, ClassCastException_init__Create_)
     return tmp
 
@@ -13343,43 +13289,39 @@ class ClassCastException(RuntimeException):
         captureStack(self, _init_)
     
 
-def UninitializedPropertyAccessException_init__Init_(_this):
-    RuntimeException_init__Init_(_this)
-    UninitializedPropertyAccessException.__init__(self)
-    return _this
+def UninitializedPropertyAccessException_init__Init_():
+    RuntimeException_init__Init_()
+    return UninitializedPropertyAccessException()
 
 def UninitializedPropertyAccessException_init__Create_():
-    tmp = UninitializedPropertyAccessException_init__Init_(Object_create())
+    tmp = UninitializedPropertyAccessException_init__Init_()
     captureStack(tmp, UninitializedPropertyAccessException_init__Create_)
     return tmp
 
-def UninitializedPropertyAccessException_init__Init__0(message, _this):
-    RuntimeException_init__Init__0(message, _this)
-    UninitializedPropertyAccessException.__init__(self)
-    return _this
+def UninitializedPropertyAccessException_init__Init__0(message):
+    RuntimeException_init__Init__0(message)
+    return UninitializedPropertyAccessException()
 
 def UninitializedPropertyAccessException_init__Create__0(message):
-    tmp = UninitializedPropertyAccessException_init__Init__0(message, Object_create())
+    tmp = UninitializedPropertyAccessException_init__Init__0(message)
     captureStack(tmp, UninitializedPropertyAccessException_init__Create_)
     return tmp
 
-def UninitializedPropertyAccessException_init__Init__1(message, cause, _this):
-    RuntimeException_init__Init__1(message, cause, _this)
-    UninitializedPropertyAccessException.__init__(self)
-    return _this
+def UninitializedPropertyAccessException_init__Init__1(message, cause):
+    RuntimeException_init__Init__1(message, cause)
+    return UninitializedPropertyAccessException()
 
 def UninitializedPropertyAccessException_init__Create__1(message, cause):
-    tmp = UninitializedPropertyAccessException_init__Init__1(message, cause, Object_create())
+    tmp = UninitializedPropertyAccessException_init__Init__1(message, cause)
     captureStack(tmp, UninitializedPropertyAccessException_init__Create_)
     return tmp
 
-def UninitializedPropertyAccessException_init__Init__2(cause, _this):
-    RuntimeException_init__Init__2(cause, _this)
-    UninitializedPropertyAccessException.__init__(self)
-    return _this
+def UninitializedPropertyAccessException_init__Init__2(cause):
+    RuntimeException_init__Init__2(cause)
+    return UninitializedPropertyAccessException()
 
 def UninitializedPropertyAccessException_init__Create__2(cause):
-    tmp = UninitializedPropertyAccessException_init__Init__2(cause, Object_create())
+    tmp = UninitializedPropertyAccessException_init__Init__2(cause)
     captureStack(tmp, UninitializedPropertyAccessException_init__Create_)
     return tmp
 


### PR DESCRIPTION
This PR tries to solve the problem described in this doc: https://github.com/krzema12/kotlin-python/wiki/Notes-on-getting-rid-of-%22NameError:-name-'Object_create'-is-not-defined%22

Regressions:

```
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSelfcreate
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes$Inner > testProperOuter
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testKt4174
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterAndLocalCapturedInLocalClass
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testOuterEnumEntryCapturedInLambdaInInnerClass
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Closures$CaptureInSuperConstructorCall > testProperValueCapturedByClosure1
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$AnonymousObject > testSuperConstructorWithObjectParameter
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOf
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfCapturedType
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChain
org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenInlineTestGenerated$Enum > testValueOfChainCapturedType
```

----

# org.jetbrains.kotlin.python.test.ir.semantics.IrPythonCodegenBoxTestGenerated$Classes > testSelfcreate

Calling base class constructor inside the primary constructor got broken. To fix it, one has to check in which context the constructor is called, and create a relevant kind of call.

```
     def __init__(self, this_0):
         self.this_0 = this_0
-        A.__init__(self, this_0.b)
+        A(this_0.b)
```

