### PR TITLE
Translate build and test workflow to Kotlin DSL

### DIFF
--- a/.github/workflows/build_and_test.main.kts
+++ b/.github/workflows/build_and_test.main.kts
@@ -107,24 +107,32 @@ val buildAndTest = workflow(
             command = "${gradle(":python:box.tests:\${{ matrix.testTask }}")} || true",
             condition = "always()",
         )
+
+        val failedTestsFile = "failed-tests.txt"
+        val boxTestsReportFile = "box-tests-report.tsv"
+        val failureCountFile = "failure-count.tsv"
+
+        fun reportsFile(fileName: String) =
+            "python/box.tests/reports/\${{ matrix.testTask }}/$fileName"
+
         run(
             name = "Generate box tests reports",
-            command = "python/experiments/generate-box-tests-reports.main.kts --test-task=\${{ matrix.testTask }} --failed-tests-report-path=failed-tests.txt --box-tests-report-path=box-tests-report.tsv --failure-count-report-path=failure-count.tsv",
+            command = "python/experiments/generate-box-tests-reports.main.kts --test-task=\${{ matrix.testTask }} --failed-tests-report-path=$failedTestsFile --box-tests-report-path=$boxTestsReportFile --failure-count-report-path=$failureCountFile",
             condition = "always()",
         )
         run(
-            name = "Compare failed-tests.txt",
-            command = "diff -u failed-tests.txt python/box.tests/reports/\${{ matrix.testTask }}/failed-tests.txt",
+            name = "Compare $failedTestsFile",
+            command = "diff -u $failedTestsFile ${reportsFile(failedTestsFile)}",
             condition = "always()",
         )
         run(
-            name = "Compare box-tests-report.tsv",
-            command = "diff -u box-tests-report.tsv python/box.tests/reports/\${{ matrix.testTask }}/box-tests-report.tsv",
+            name = "Compare $boxTestsReportFile",
+            command = "diff -u $boxTestsReportFile ${reportsFile(boxTestsReportFile)}",
             condition = "always()",
         )
         run(
-            name = "Compare failure-count.tsv",
-            command = "diff -u failure-count.tsv python/box.tests/reports/\${{ matrix.testTask }}/failure-count.tsv",
+            name = "Compare $failureCountFile",
+            command = "diff -u $failureCountFile ${reportsFile(failureCountFile)}",
             condition = "always()",
         )
     }

--- a/.github/workflows/build_and_test.main.kts
+++ b/.github/workflows/build_and_test.main.kts
@@ -11,6 +11,10 @@ import it.krzeminski.githubactions.dsl.workflow
 import it.krzeminski.githubactions.yaml.toYaml
 import java.nio.file.Paths
 
+fun withJavaConfigured(command: String) = "JDK_9=\"\$JAVA_HOME\" $command"
+
+fun gradle(command: String) = withJavaConfigured("./gradlew $command")
+
 val buildAndTest = workflow(
     name = "Build and test",
     on = listOf(Push, WorkflowDispatch),
@@ -47,16 +51,16 @@ val buildAndTest = workflow(
 
         run(
             name = "Clean",
-            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew clean",
+            command = gradle("clean"),
         )
         run(
             name = "Run ast tests",
-            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew :python:ast:test",
+            command = gradle(":python:ast:test"),
             condition = "always()",
         )
         run(
             name = "Build",
-            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew dist",
+            command = gradle("dist"),
         )
 
         run(
@@ -94,13 +98,13 @@ val buildAndTest = workflow(
 
         run(
             name = "Run end-to-end tests",
-            command = "JDK_9=\"\$JAVA_HOME\" python/e2e-tests/run.sh",
+            command = withJavaConfigured("python/e2e-tests/run.sh"),
             condition = "\${{ matrix.testTask == 'pythonTest' }}", // TODO: run e2e tests for MicroPython too (#85)
         )
 
         run(
             name = "Run box tests (succeed even if they fail)",
-            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew :python:box.tests:\${{ matrix.testTask }} || true",
+            command = "${gradle(":python:box.tests:\${{ matrix.testTask }}")} || true",
             condition = "always()",
         )
         run(

--- a/.github/workflows/build_and_test.main.kts
+++ b/.github/workflows/build_and_test.main.kts
@@ -65,7 +65,13 @@ val buildAndTest = workflow(
 
         run(
             name = "Compile python.kt to Python",
-            command = "dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -output out_ir.py python/experiments/python.kt",
+            command = """
+                dist/kotlinc/bin/kotlinc-py \
+                -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+                -Xir-produce-js \
+                -output out_ir.py \
+                python/experiments/python.kt
+            """.trimIndent(),
             condition = "always()",
         )
         run(
@@ -76,7 +82,14 @@ val buildAndTest = workflow(
 
         run(
             name = "Compile python.kt to JavaScript",
-            command = "dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output out-ir.js python/experiments/python.kt",
+            command = """
+                dist/kotlinc/bin/kotlinc-js \
+                -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+                -Xir-produce-js \
+                -Xir-property-lazy-initialization \
+                -output out-ir.js \
+                python/experiments/python.kt
+            """.trimIndent(),
             condition = "always()",
         )
         run(
@@ -87,7 +100,14 @@ val buildAndTest = workflow(
 
         run(
             name = "Generate stats about missing IR mapping",
-            command = "less python/experiments/generated/out_ir.py | grep -Po \"visit[a-zA-Z0-9_]+\" | sort | uniq -c | sort -nr > missing.txt",
+            command = """
+                less python/experiments/generated/out_ir.py | \
+                grep -Po "visit[a-zA-Z0-9_]+" | \
+                sort | \
+                uniq -c | \
+                sort -nr \
+                > missing.txt
+            """.trimIndent(),
             condition = "always()",
         )
         run(
@@ -117,7 +137,13 @@ val buildAndTest = workflow(
 
         run(
             name = "Generate box tests reports",
-            command = "python/experiments/generate-box-tests-reports.main.kts --test-task=\${{ matrix.testTask }} --failed-tests-report-path=$failedTestsFile --box-tests-report-path=$boxTestsReportFile --failure-count-report-path=$failureCountFile",
+            command = """
+                python/experiments/generate-box-tests-reports.main.kts \
+                --test-task=${"$"}{{ matrix.testTask }} \
+                --failed-tests-report-path=$failedTestsFile \
+                --box-tests-report-path=$boxTestsReportFile \
+                --failure-count-report-path=$failureCountFile
+            """.trimIndent(),
             condition = "always()",
         )
         run(

--- a/.github/workflows/build_and_test.main.kts
+++ b/.github/workflows/build_and_test.main.kts
@@ -1,0 +1,130 @@
+#!/usr/bin/env kotlin
+
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.4.1")
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV2
+import it.krzeminski.githubactions.actions.actions.FetchDepth.Infinite
+import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.Trigger.Push
+import it.krzeminski.githubactions.domain.Trigger.WorkflowDispatch
+import it.krzeminski.githubactions.dsl.workflow
+import it.krzeminski.githubactions.yaml.toYaml
+import java.nio.file.Paths
+
+val buildAndTest = workflow(
+    name = "Build and test",
+    on = listOf(Push, WorkflowDispatch),
+    sourceFile = Paths.get(".github/workflows/build_and_test.main.kts"),
+    targetFile = Paths.get(".github/workflows/build_and_test.yml"),
+) {
+    job(
+        name = "build_and_test",
+        runsOn = UbuntuLatest,
+        strategyMatrix = mapOf(
+            "testTask" to listOf(
+                "pythonTest",
+                "microPythonTest",
+            )
+        ),
+    ) {
+        uses(
+            name = "Fetch the whole git history (to be able to calculate some stats based on it)",
+            action = CheckoutV2(fetchDepth = Infinite),
+        )
+        run(
+            name = "Install Kotlin for scripting",
+            command = "sudo snap install --classic kotlin",
+        )
+        run(
+            name = "Install MicroPython",
+            command = "sudo snap install micropython",
+            condition = "\${{ matrix.testTask == 'microPythonTest' }}",
+        )
+        run(
+            name = "Disable old Java for Kotlin",
+            command = "echo \"kotlin.build.isObsoleteJdkOverrideEnabled=true\" > local.properties",
+        )
+
+        run(
+            name = "Clean",
+            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew clean",
+        )
+        run(
+            name = "Run ast tests",
+            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew :python:ast:test",
+            condition = "always()",
+        )
+        run(
+            name = "Build",
+            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew dist",
+        )
+
+        run(
+            name = "Compile python.kt to Python",
+            command = "dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -output out_ir.py python/experiments/python.kt",
+            condition = "always()",
+        )
+        run(
+            name = "Compare out_ir.py",
+            command = "diff -u out_ir.py python/experiments/generated/out_ir.py",
+            condition = "always()",
+        )
+
+        run(
+            name = "Compile python.kt to JavaScript",
+            command = "dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output out-ir.js python/experiments/python.kt",
+            condition = "always()",
+        )
+        run(
+            name = "Compare out-ir.js",
+            command = "diff -u out-ir.js python/experiments/generated/out-ir.js",
+            condition = "always()",
+        )
+
+        run(
+            name = "Generate stats about missing IR mapping",
+            command = "less python/experiments/generated/out_ir.py | grep -Po \"visit[a-zA-Z0-9_]+\" | sort | uniq -c | sort -nr > missing.txt",
+            condition = "always()",
+        )
+        run(
+            name = "Compare missing.txt",
+            command = "diff -u missing.txt python/experiments/generated/missing.txt",
+            condition = "always()",
+        )
+
+        run(
+            name = "Run end-to-end tests",
+            command = "JDK_9=\"\$JAVA_HOME\" python/e2e-tests/run.sh",
+            condition = "\${{ matrix.testTask == 'pythonTest' }}", // TODO: run e2e tests for MicroPython too (#85)
+        )
+
+        run(
+            name = "Run box tests (succeed even if they fail)",
+            command = "JDK_9=\"\$JAVA_HOME\" ./gradlew :python:box.tests:\${{ matrix.testTask }} || true",
+            condition = "always()",
+        )
+        run(
+            name = "Generate box tests reports",
+            command = "python/experiments/generate-box-tests-reports.main.kts --test-task=\${{ matrix.testTask }} --failed-tests-report-path=failed-tests.txt --box-tests-report-path=box-tests-report.tsv --failure-count-report-path=failure-count.tsv",
+            condition = "always()",
+        )
+        run(
+            name = "Compare failed-tests.txt",
+            command = "diff -u failed-tests.txt python/box.tests/reports/\${{ matrix.testTask }}/failed-tests.txt",
+            condition = "always()",
+        )
+        run(
+            name = "Compare box-tests-report.tsv",
+            command = "diff -u box-tests-report.tsv python/box.tests/reports/\${{ matrix.testTask }}/box-tests-report.tsv",
+            condition = "always()",
+        )
+        run(
+            name = "Compare failure-count.tsv",
+            command = "diff -u failure-count.tsv python/box.tests/reports/\${{ matrix.testTask }}/failure-count.tsv",
+            condition = "always()",
+        )
+    }
+}
+
+println(buildAndTest.toYaml())
+

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,3 +1,7 @@
+# This file was generated using Kotlin DSL (.github/workflows/build_and_test.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
 name: Build and test
 
 on:
@@ -5,8 +9,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_test:
-    runs-on: ubuntu-latest
+  "check_yaml_consistency":
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Install Kotlin
+        run: sudo snap install --classic kotlin
+      - name: Consistency check
+        run: diff -u '.github/workflows/build_and_test.yml' <('.github/workflows/build_and_test.main.kts')
+  "build_and_test":
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check_yaml_consistency"
     strategy:
       matrix:
         testTask:
@@ -24,7 +39,6 @@ jobs:
         if: ${{ matrix.testTask == 'microPythonTest' }}
       - name: Disable old Java for Kotlin
         run: echo "kotlin.build.isObsoleteJdkOverrideEnabled=true" > local.properties
-
       - name: Clean
         run: JDK_9="$JAVA_HOME" ./gradlew clean
       - name: Run ast tests
@@ -32,32 +46,27 @@ jobs:
         if: always()
       - name: Build
         run: JDK_9="$JAVA_HOME" ./gradlew dist
-
       - name: Compile python.kt to Python
         run: dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -output out_ir.py python/experiments/python.kt
         if: always()
       - name: Compare out_ir.py
         run: diff -u out_ir.py python/experiments/generated/out_ir.py
         if: always()
-
       - name: Compile python.kt to JavaScript
         run: dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output out-ir.js python/experiments/python.kt
         if: always()
       - name: Compare out-ir.js
         run: diff -u out-ir.js python/experiments/generated/out-ir.js
         if: always()
-
       - name: Generate stats about missing IR mapping
         run: less python/experiments/generated/out_ir.py | grep -Po "visit[a-zA-Z0-9_]+" | sort | uniq -c | sort -nr > missing.txt
         if: always()
       - name: Compare missing.txt
         run: diff -u missing.txt python/experiments/generated/missing.txt
         if: always()
-
       - name: Run end-to-end tests
         run: JDK_9="$JAVA_HOME" python/e2e-tests/run.sh
-        if: ${{ matrix.testTask == 'pythonTest' }}  # TODO: run e2e tests for MicroPython too (#85)
-
+        if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Run box tests (succeed even if they fail)
         run: JDK_9="$JAVA_HOME" ./gradlew :python:box.tests:${{ matrix.testTask }} || true
         if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,19 +47,36 @@ jobs:
       - name: Build
         run: JDK_9="$JAVA_HOME" ./gradlew dist
       - name: Compile python.kt to Python
-        run: dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -output out_ir.py python/experiments/python.kt
+        run: |
+          dist/kotlinc/bin/kotlinc-py \
+          -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+          -Xir-produce-js \
+          -output out_ir.py \
+          python/experiments/python.kt
         if: always()
       - name: Compare out_ir.py
         run: diff -u out_ir.py python/experiments/generated/out_ir.py
         if: always()
       - name: Compile python.kt to JavaScript
-        run: dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output out-ir.js python/experiments/python.kt
+        run: |
+          dist/kotlinc/bin/kotlinc-js \
+          -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+          -Xir-produce-js \
+          -Xir-property-lazy-initialization \
+          -output out-ir.js \
+          python/experiments/python.kt
         if: always()
       - name: Compare out-ir.js
         run: diff -u out-ir.js python/experiments/generated/out-ir.js
         if: always()
       - name: Generate stats about missing IR mapping
-        run: less python/experiments/generated/out_ir.py | grep -Po "visit[a-zA-Z0-9_]+" | sort | uniq -c | sort -nr > missing.txt
+        run: |
+          less python/experiments/generated/out_ir.py | \
+          grep -Po "visit[a-zA-Z0-9_]+" | \
+          sort | \
+          uniq -c | \
+          sort -nr \
+          > missing.txt
         if: always()
       - name: Compare missing.txt
         run: diff -u missing.txt python/experiments/generated/missing.txt
@@ -71,7 +88,12 @@ jobs:
         run: JDK_9="$JAVA_HOME" ./gradlew :python:box.tests:${{ matrix.testTask }} || true
         if: always()
       - name: Generate box tests reports
-        run: python/experiments/generate-box-tests-reports.main.kts --test-task=${{ matrix.testTask }} --failed-tests-report-path=failed-tests.txt --box-tests-report-path=box-tests-report.tsv --failure-count-report-path=failure-count.tsv
+        run: |
+          python/experiments/generate-box-tests-reports.main.kts \
+          --test-task=${{ matrix.testTask }} \
+          --failed-tests-report-path=failed-tests.txt \
+          --box-tests-report-path=box-tests-report.tsv \
+          --failure-count-report-path=failure-count.tsv
         if: always()
       - name: Compare failed-tests.txt
         run: diff -u failed-tests.txt python/box.tests/reports/${{ matrix.testTask }}/failed-tests.txt


### PR DESCRIPTION
Part of https://github.com/krzema12/github-actions-kotlin-dsl/issues/3.

The workflows in kotlin-python are the main inspiration to me to create https://github.com/krzema12/github-actions-kotlin-dsl/.
That's why I'd like to use it in this project, so that we have a real-life scenario and "customer zero".

I'm migrating just one workflow as an experiment, and once it's merged, I'll do the same with the other one. By having them in the same Kotlin file or sharing common Kotlin file, we'll manage to remove some across-workflows duplication.

# Testing

I compared workflows in runtime, before and after this change:

* `pythonTest`: [before](https://github.com/krzema12/kotlin-python/runs/4626859336?check_suite_focus=true) and [after](https://github.com/krzema12/kotlin-python/runs/4919889181?check_suite_focus=true)
* `microPythonTest`: [before](https://github.com/krzema12/kotlin-python/runs/4626859354?check_suite_focus=true) and [after](https://github.com/krzema12/kotlin-python/runs/4919889262?check_suite_focus=true)

I also checked how it works in case of forgetting to regenerate the YAML. It now fails at runtime:

![Screenshot from 2022-01-19 12-25-59](https://user-images.githubusercontent.com/3110813/150143500-08648eb0-ee61-4ee6-8e60-259b2d2051f2.png)

and in the future we can e.g. add auto-generated job that regenerates the YAML. The golden grail is GitHub supporting such Kotlin DSL, without any (semi)manual generation steps.