### PR TITLE
Translate 'Generate reports' workflow to Kotlin DSL

### DIFF
--- a/.github/workflows/generate_reports.main.kts
+++ b/.github/workflows/generate_reports.main.kts
@@ -1,0 +1,159 @@
+#!/usr/bin/env kotlin
+
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.6.0")
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV2
+import it.krzeminski.githubactions.actions.actions.CheckoutV2.FetchDepth.Infinite
+import it.krzeminski.githubactions.actions.actions.DownloadArtifactV2
+import it.krzeminski.githubactions.actions.actions.UploadArtifactV2
+import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.triggers.WorkflowDispatch
+import it.krzeminski.githubactions.dsl.workflow
+import it.krzeminski.githubactions.yaml.toYaml
+import java.nio.file.Paths
+
+fun withJavaConfigured(command: String) = "JDK_9=\"\$JAVA_HOME\" $command"
+
+fun gradle(command: String) = withJavaConfigured("./gradlew $command")
+
+val generateReportsWorkflow = workflow(
+    name = "Generate reports",
+    on = listOf(WorkflowDispatch()),
+    sourceFile = Paths.get(".github/workflows/generate_reports.main.kts"),
+    targetFile = Paths.get(".github/workflows/generate_reports.yml"),
+) {
+    val generateReports = job(
+        name = "generate_reports",
+        runsOn = UbuntuLatest,
+        strategyMatrix = mapOf(
+            "testTask" to listOf(
+                "pythonTest",
+                "microPythonTest",
+            )
+        ),
+    ) {
+        uses(
+            name = "Fetch the whole git history (to be able to calculate some stats based on it)",
+            action = CheckoutV2(fetchDepth = Infinite),
+        )
+        run(
+            name = "Install Kotlin for scripting",
+            command = "sudo snap install --classic kotlin",
+        )
+        run(
+            name = "Install MicroPython",
+            command = "sudo snap install micropython",
+            condition = "\${{ matrix.testTask == 'microPythonTest' }}",
+        )
+        run(
+            name = "Disable old Java for Kotlin",
+            command = "echo \"kotlin.build.isObsoleteJdkOverrideEnabled=true\" > local.properties",
+        )
+
+        run(
+            name = "Clean",
+            command = gradle("clean"),
+        )
+        run(
+            name = "Build",
+            command = gradle("dist"),
+        )
+
+        run(
+            name = "Compile python.kt to Python",
+            command = "dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-py -output python/experiments/generated/out_ir.py python/experiments/python.kt",
+            condition = "\${{ matrix.testTask == 'pythonTest' }}",
+        )
+        run(
+            name = "Compile python.kt to JavaScript",
+            command = "dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output python/experiments/generated/out-ir.js python/experiments/python.kt".trimIndent(),
+            condition = "\${{ matrix.testTask == 'pythonTest' }}",
+        )
+
+        run(
+            name = "Generate stats about missing IR mapping",
+            command = "less python/experiments/generated/out_ir.py | grep -Po \"visit[a-zA-Z0-9_]+\" | sort | uniq -c | sort -nr > python/experiments/generated/missing.txt",
+            condition = "\${{ matrix.testTask == 'pythonTest' }}",
+        )
+
+        run(
+            name = "Run end-to-end tests",
+            command = withJavaConfigured("python/e2e-tests/run.sh"),
+            condition = "\${{ matrix.testTask == 'pythonTest' }}", // TODO: run e2e tests for MicroPython too (#85)
+        )
+
+        run(
+            name = "Run box tests (succeed even if they fail)",
+            command = "${gradle(":python:box.tests:\${{ matrix.testTask }}")} || true",
+        )
+        run(
+            name = "Generate box tests reports",
+            command = "python/experiments/generate-box-tests-reports.main.kts --test-task=\${{ matrix.testTask }}",
+        )
+
+        uses(
+            name = "Upload common artifact",
+            action = UploadArtifactV2(
+                name = "common-artifact",
+                path = listOf(
+                    "python/box.tests/reports/git-history-plot.svg",
+                    "python/experiments/generated",
+                )
+            ),
+            condition = "\${{ matrix.testTask == 'pythonTest' }}",
+        )
+        uses(
+            name = "Upload \${{ matrix.testTask }} artifact",
+            action = UploadArtifactV2(
+                name = "\${{ matrix.testTask }}-artifact",
+                path = listOf("python/box.tests/reports/\${{ matrix.testTask }}"),
+            )
+        )
+    }
+
+    job(
+        name = "update_reports",
+        needs = listOf(generateReports),
+        runsOn = UbuntuLatest,
+    ) {
+        uses(
+            name = "Check out",
+            action = CheckoutV2(),
+        )
+
+        uses(
+            name = "Download common artifact",
+            action = DownloadArtifactV2(
+                name = "common-artifact",
+                path = "python",
+            )
+        )
+        uses(
+            name = "Download pythonTest artifact",
+            action = DownloadArtifactV2(
+                name = "pythonTest-artifact",
+                path = "python/box.tests/reports/pythonTest",
+            )
+        )
+        uses(
+            name = "Download microPythonTest artifact",
+            action = DownloadArtifactV2(
+                name = "microPythonTest-artifact",
+                path = "python/box.tests/reports/microPythonTest",
+            )
+        )
+
+        run(
+            name = "Commit and push",
+            command = """
+                git config --global user.email "<>"
+                git config --global user.name "GitHub Actions Bot"
+                git add python/box.tests/reports python/experiments
+                git commit --allow-empty -m "Generate reports for ${'$'}GITHUB_SHA"  # an empty commit explicitly shows that reports are up-to-date
+                git push
+            """.trimIndent()
+        )
+    }
+}
+
+println(generateReportsWorkflow.toYaml())

--- a/.github/workflows/generate_reports.main.kts
+++ b/.github/workflows/generate_reports.main.kts
@@ -61,18 +61,38 @@ val generateReportsWorkflow = workflow(
 
         run(
             name = "Compile python.kt to Python",
-            command = "dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-py -output python/experiments/generated/out_ir.py python/experiments/python.kt",
+            command = """
+                dist/kotlinc/bin/kotlinc-py \
+                -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+                -Xir-produce-py \
+                -output python/experiments/generated/out_ir.py \
+                python/experiments/python.kt
+            """.trimIndent(),
             condition = "\${{ matrix.testTask == 'pythonTest' }}",
         )
         run(
             name = "Compile python.kt to JavaScript",
-            command = "dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output python/experiments/generated/out-ir.js python/experiments/python.kt".trimIndent(),
+            command = """
+                dist/kotlinc/bin/kotlinc-js \
+                -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+                -Xir-produce-js \
+                -Xir-property-lazy-initialization \
+                -output python/experiments/generated/out-ir.js \
+                python/experiments/python.kt
+            """.trimIndent(),
             condition = "\${{ matrix.testTask == 'pythonTest' }}",
         )
 
         run(
             name = "Generate stats about missing IR mapping",
-            command = "less python/experiments/generated/out_ir.py | grep -Po \"visit[a-zA-Z0-9_]+\" | sort | uniq -c | sort -nr > python/experiments/generated/missing.txt",
+            command = """
+                less python/experiments/generated/out_ir.py \
+                | grep -Po "visit[a-zA-Z0-9_]+" \
+                | sort \
+                | uniq -c \
+                | sort -nr \
+                > python/experiments/generated/missing.txt
+            """.trimIndent(),
             condition = "\${{ matrix.testTask == 'pythonTest' }}",
         )
 

--- a/.github/workflows/generate_reports.yml
+++ b/.github/workflows/generate_reports.yml
@@ -43,13 +43,30 @@ jobs:
       - name: Build
         run: JDK_9="$JAVA_HOME" ./gradlew dist
       - name: Compile python.kt to Python
-        run: dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-py -output python/experiments/generated/out_ir.py python/experiments/python.kt
+        run: |
+          dist/kotlinc/bin/kotlinc-py \
+          -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+          -Xir-produce-py \
+          -output python/experiments/generated/out_ir.py \
+          python/experiments/python.kt
         if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Compile python.kt to JavaScript
-        run: dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output python/experiments/generated/out-ir.js python/experiments/python.kt
+        run: |
+          dist/kotlinc/bin/kotlinc-js \
+          -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar \
+          -Xir-produce-js \
+          -Xir-property-lazy-initialization \
+          -output python/experiments/generated/out-ir.js \
+          python/experiments/python.kt
         if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Generate stats about missing IR mapping
-        run: less python/experiments/generated/out_ir.py | grep -Po "visit[a-zA-Z0-9_]+" | sort | uniq -c | sort -nr > python/experiments/generated/missing.txt
+        run: |
+          less python/experiments/generated/out_ir.py \
+          | grep -Po "visit[a-zA-Z0-9_]+" \
+          | sort \
+          | uniq -c \
+          | sort -nr \
+          > python/experiments/generated/missing.txt
         if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Run end-to-end tests
         run: JDK_9="$JAVA_HOME" python/e2e-tests/run.sh

--- a/.github/workflows/generate_reports.yml
+++ b/.github/workflows/generate_reports.yml
@@ -1,11 +1,26 @@
+# This file was generated using Kotlin DSL (.github/workflows/generate_reports.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
 name: Generate reports
 
 on:
   workflow_dispatch:
 
 jobs:
-  generate_reports:
-    runs-on: ubuntu-latest
+  "check_yaml_consistency":
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Install Kotlin
+        run: sudo snap install --classic kotlin
+      - name: Consistency check
+        run: diff -u '.github/workflows/generate_reports.yml' <('.github/workflows/generate_reports.main.kts')
+  "generate_reports":
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check_yaml_consistency"
     strategy:
       matrix:
         testTask:
@@ -23,53 +38,47 @@ jobs:
         if: ${{ matrix.testTask == 'microPythonTest' }}
       - name: Disable old Java for Kotlin
         run: echo "kotlin.build.isObsoleteJdkOverrideEnabled=true" > local.properties
-
       - name: Clean
         run: JDK_9="$JAVA_HOME" ./gradlew clean
       - name: Build
         run: JDK_9="$JAVA_HOME" ./gradlew dist
-
       - name: Compile python.kt to Python
         run: dist/kotlinc/bin/kotlinc-py -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-py -output python/experiments/generated/out_ir.py python/experiments/python.kt
         if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Compile python.kt to JavaScript
         run: dist/kotlinc/bin/kotlinc-js -libraries dist/kotlinc/lib/kotlin-stdlib-js.jar -Xir-produce-js -Xir-property-lazy-initialization -output python/experiments/generated/out-ir.js python/experiments/python.kt
         if: ${{ matrix.testTask == 'pythonTest' }}
-
       - name: Generate stats about missing IR mapping
         run: less python/experiments/generated/out_ir.py | grep -Po "visit[a-zA-Z0-9_]+" | sort | uniq -c | sort -nr > python/experiments/generated/missing.txt
         if: ${{ matrix.testTask == 'pythonTest' }}
-
       - name: Run end-to-end tests
         run: JDK_9="$JAVA_HOME" python/e2e-tests/run.sh
-        if: ${{ matrix.testTask == 'pythonTest' }}  # TODO: run e2e tests for MicroPython too (#85)
-
+        if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Run box tests (succeed even if they fail)
         run: JDK_9="$JAVA_HOME" ./gradlew :python:box.tests:${{ matrix.testTask }} || true
       - name: Generate box tests reports
         run: python/experiments/generate-box-tests-reports.main.kts --test-task=${{ matrix.testTask }}
-
       - name: Upload common artifact
-        if: ${{ matrix.testTask == 'pythonTest' }}
         uses: actions/upload-artifact@v2
         with:
           name: common-artifact
           path: |
             python/box.tests/reports/git-history-plot.svg
             python/experiments/generated
+        if: ${{ matrix.testTask == 'pythonTest' }}
       - name: Upload ${{ matrix.testTask }} artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.testTask }}-artifact
           path: python/box.tests/reports/${{ matrix.testTask }}
-
-  update_reports:
-    needs: generate_reports
-    runs-on: ubuntu-latest
+  "update_reports":
+    runs-on: "ubuntu-latest"
+    needs:
+      - "generate_reports"
+      - "check_yaml_consistency"
     steps:
       - name: Check out
         uses: actions/checkout@v2
-
       - name: Download common artifact
         uses: actions/download-artifact@v2
         with:
@@ -85,7 +94,6 @@ jobs:
         with:
           name: microPythonTest-artifact
           path: python/box.tests/reports/microPythonTest
-
       - name: Commit and push
         run: |
           git config --global user.email "<>"


### PR DESCRIPTION
Just a simple translation as a first step, without deduplication with
parts in 'Build and test'. It will be tackled in a separate change.

# Testing

Ran report generation here: https://github.com/krzema12/kotlin-python/actions/runs/1783091772