### PR TITLE
Bump github-actions-kotlin-dsl to 0.10.0 and create workflow regeneration script

### DIFF
--- a/.github/workflows/_generate_workflows.main.kts
+++ b/.github/workflows/_generate_workflows.main.kts
@@ -1,0 +1,13 @@
+#!/usr/bin/env kotlin
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.10.0")
+
+@file:Import("build_and_test.main.kts")
+@file:Import("generate_reports.main.kts")
+
+import it.krzeminski.githubactions.yaml.writeToFile
+
+listOf(
+    buildAndTest,
+    generateReportsWorkflow
+).forEach { it.writeToFile() }
+

--- a/.github/workflows/build_and_test.main.kts
+++ b/.github/workflows/build_and_test.main.kts
@@ -1,6 +1,6 @@
 #!/usr/bin/env kotlin
 
-@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.9.0")
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.10.0")
 @file:Import("Common.main.kts")
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
@@ -9,13 +9,12 @@ import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.domain.triggers.WorkflowDispatch
 import it.krzeminski.githubactions.dsl.workflow
-import it.krzeminski.githubactions.yaml.toYaml
 import java.nio.file.Paths
 
 val buildAndTest = workflow(
     name = "Build and test",
     on = listOf(Push(), WorkflowDispatch()),
-    sourceFile = Paths.get(".github/workflows/build_and_test.main.kts"),
+    sourceFile = Paths.get(".github/workflows/_generate_workflows.main.kts"),
     targetFile = Paths.get(".github/workflows/build_and_test.yml"),
 ) {
     job(
@@ -160,6 +159,4 @@ val buildAndTest = workflow(
         )
     }
 }
-
-println(buildAndTest.toYaml())
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-# This file was generated using Kotlin DSL (.github/workflows/build_and_test.main.kts).
+# This file was generated using Kotlin DSL (.github/workflows/_generate_workflows.main.kts).
 # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
@@ -14,13 +14,16 @@ jobs:
     steps:
       - id: step-0
         name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: step-1
         name: Install Kotlin
         run: sudo snap install --classic kotlin
       - id: step-2
+        name: Execute script
+        run: rm '.github/workflows/build_and_test.yml' && '.github/workflows/_generate_workflows.main.kts'
+      - id: step-3
         name: Consistency check
-        run: diff -u '.github/workflows/build_and_test.yml' <('.github/workflows/build_and_test.main.kts')
+        run: git diff --exit-code '.github/workflows/build_and_test.yml'
   "build_and_test":
     runs-on: "ubuntu-latest"
     needs:

--- a/.github/workflows/generate_reports.main.kts
+++ b/.github/workflows/generate_reports.main.kts
@@ -1,6 +1,6 @@
 #!/usr/bin/env kotlin
 
-@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.9.0")
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.10.0")
 @file:Import("Common.main.kts")
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
@@ -16,7 +16,7 @@ import java.nio.file.Paths
 val generateReportsWorkflow = workflow(
     name = "Generate reports",
     on = listOf(WorkflowDispatch()),
-    sourceFile = Paths.get(".github/workflows/generate_reports.main.kts"),
+    sourceFile = Paths.get(".github/workflows/_generate_workflows.main.kts"),
     targetFile = Paths.get(".github/workflows/generate_reports.yml"),
 ) {
     val generateReports = job(
@@ -173,4 +173,3 @@ val generateReportsWorkflow = workflow(
     }
 }
 
-println(generateReportsWorkflow.toYaml())

--- a/.github/workflows/generate_reports.yml
+++ b/.github/workflows/generate_reports.yml
@@ -1,4 +1,4 @@
-# This file was generated using Kotlin DSL (.github/workflows/generate_reports.main.kts).
+# This file was generated using Kotlin DSL (.github/workflows/_generate_workflows.main.kts).
 # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
@@ -13,13 +13,16 @@ jobs:
     steps:
       - id: step-0
         name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: step-1
         name: Install Kotlin
         run: sudo snap install --classic kotlin
       - id: step-2
+        name: Execute script
+        run: rm '.github/workflows/generate_reports.yml' && '.github/workflows/_generate_workflows.main.kts'
+      - id: step-3
         name: Consistency check
-        run: diff -u '.github/workflows/generate_reports.yml' <('.github/workflows/generate_reports.main.kts')
+        run: git diff --exit-code '.github/workflows/generate_reports.yml'
   "generate_reports":
     runs-on: "ubuntu-latest"
     needs:


### PR DESCRIPTION
From now on, to regenerate the workflows, call
`.github/workflows/_generate_workflows.main.kts`.

Just beware of this bug in Kotlin scripting: https://youtrack.jetbrains.com/issue/KT-51567
which makes regeneration tricky if you already did on your machine, it and now modifying some workflow.